### PR TITLE
feat: sidebar open-tab dot indicator, custom unsaved-changes dialog

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -826,6 +826,112 @@ export default function App() {
 
       <UndoToast action={undoAction} />
 
+      {/* Unsaved changes dialog */}
+      {tabsHook.pendingCloseTabId && (() => {
+        const tab = tabsHook.tabs.find((t) => t.id === tabsHook.pendingCloseTabId);
+        if (!tab) return null;
+        return (
+          <div
+            style={{
+              position: "fixed",
+              inset: 0,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              zIndex: 1000,
+            }}
+          >
+            <div
+              onClick={tabsHook.cancelCloseTab}
+              style={{ position: "absolute", inset: 0, backgroundColor: "rgba(0, 0, 0, 0.3)" }}
+            />
+            <div
+              role="dialog"
+              aria-label="Unsaved changes"
+              style={{
+                position: "relative",
+                backgroundColor: "var(--color-page)",
+                border: "1px solid var(--color-border)",
+                borderRadius: "var(--radius-lg)",
+                padding: "20px 24px",
+                minWidth: "min(340px, calc(100vw - 32px))",
+                maxWidth: "min(400px, calc(100vw - 32px))",
+                boxShadow: "0 8px 32px rgba(0, 0, 0, 0.2)",
+              }}
+            >
+              <button
+                onClick={tabsHook.cancelCloseTab}
+                aria-label="Close"
+                style={{
+                  position: "absolute",
+                  top: 12,
+                  right: 12,
+                  background: "none",
+                  border: "none",
+                  cursor: "pointer",
+                  color: "var(--color-text-secondary)",
+                  fontSize: 18,
+                  lineHeight: 1,
+                  padding: "2px 6px",
+                  borderRadius: "var(--radius-sm)",
+                }}
+              >
+                ×
+              </button>
+              <div style={{ marginBottom: 16 }}>
+                <div
+                  style={{
+                    fontSize: 14,
+                    fontWeight: 600,
+                    color: "var(--color-text-primary)",
+                    marginBottom: 6,
+                  }}
+                >
+                  Unsaved changes
+                </div>
+                <div style={{ fontSize: 13, color: "var(--color-text-secondary)" }}>
+                  "{tab.title}" has unsaved changes.
+                </div>
+              </div>
+              <div style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>
+                <button
+                  onClick={() => tabsHook.forceCloseTab(tabsHook.pendingCloseTabId!)}
+                  style={{
+                    padding: "6px 14px",
+                    fontSize: 13,
+                    borderRadius: "var(--radius-md)",
+                    border: "1px solid var(--color-border)",
+                    background: "none",
+                    color: "var(--color-text-secondary)",
+                    cursor: "pointer",
+                  }}
+                >
+                  Close without saving
+                </button>
+                <button
+                  onClick={async () => {
+                    await doc.saveCurrentFile();
+                    tabsHook.forceCloseTab(tabsHook.pendingCloseTabId!);
+                  }}
+                  style={{
+                    padding: "6px 14px",
+                    fontSize: 13,
+                    borderRadius: "var(--radius-md)",
+                    border: "none",
+                    backgroundColor: "var(--color-accent)",
+                    color: "white",
+                    cursor: "pointer",
+                    fontWeight: 500,
+                  }}
+                >
+                  Save and close
+                </button>
+              </div>
+            </div>
+          </div>
+        );
+      })()}
+
       <SettingsModal
         isOpen={showSettings}
         onClose={() => setShowSettings(false)}

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -210,6 +210,7 @@ export function AppShell({
           onKeepLocalSearch={keepLocal.search}
           onSelectKeepLocalItem={(item, newTab) => { onSelectKeepLocalItem(item, newTab); closeSidebar(); }}
           onOpenSettings={onOpenSettings}
+          tabs={tabs}
         />
         </div>
 

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect, useMemo, useCallback } from "react";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { FolderOpenIcon, Search01Icon, Settings01Icon } from "@hugeicons/core-free-icons";
 import type { Document } from "@/types/document";
+import type { Tab } from "@/types/tab";
 import type { KeepLocalItem } from "@/types/keep-local";
 import type { FileResult } from "@/hooks/useSearch";
 import { SidebarKeepLocal } from "@/components/layout/SidebarKeepLocal";
@@ -19,6 +20,7 @@ interface SidebarProps {
   isSearching: boolean;
   onOpenFilePath: (path: string, newTab: boolean) => void;
   onRenameFile?: (doc: Document, newName: string) => void;
+  tabs: Tab[];
   // Keep-local props
   keepLocalItems: KeepLocalItem[];
   keepLocalIsOnline: boolean;
@@ -40,6 +42,7 @@ export function Sidebar({
   isSearching,
   onOpenFilePath,
   onRenameFile,
+  tabs,
   keepLocalItems,
   keepLocalIsOnline,
   keepLocalIsLoading,
@@ -133,6 +136,14 @@ export function Sidebar({
       debouncedKeepLocalSearch(value);
     }
   };
+
+  const openDocIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const tab of tabs) {
+      if (tab.documentId) ids.add(tab.documentId);
+    }
+    return ids;
+  }, [tabs]);
 
   const duplicateTitles = useMemo(() => {
     const counts = new Map<string, number>();
@@ -439,16 +450,19 @@ export function Sidebar({
                               }}
                               title={doc.file_path ?? doc.title ?? "Untitled"}
                             >
-                              <span
-                                style={{
-                                  fontSize: 11,
-                                  opacity: 0.5,
-                                  flexShrink: 0,
-                                  marginTop: 2,
-                                }}
-                              >
-                                {doc.source === "keep-local" ? "KL" : "F"}
-                              </span>
+                              {openDocIds.has(doc.id) && (
+                                <span
+                                  style={{
+                                    width: 5,
+                                    height: 5,
+                                    borderRadius: "50%",
+                                    backgroundColor: "var(--color-text-secondary)",
+                                    flexShrink: 0,
+                                    marginTop: 6,
+                                    opacity: 0.7,
+                                  }}
+                                />
+                              )}
                               {isRenaming ? (
                                 <input
                                   ref={renameInputRef}

--- a/src/hooks/useDocument.ts
+++ b/src/hooks/useDocument.ts
@@ -259,7 +259,14 @@ export function useDocument(autosaveEnabled = false): UseDocumentReturn {
   }, [currentDoc, refreshRecentDocs]);
 
   const saveCurrentFile = useCallback(async () => {
-    if (!filePath || !isDirty) return;
+    if (!isDirty) return;
+
+    // Keep-local articles have no file path — annotations are already in SQLite,
+    // so just clear the dirty flag.
+    if (!filePath) {
+      setIsDirty(false);
+      return;
+    }
 
     try {
       await saveFileCommand(filePath, content);


### PR DESCRIPTION
## Summary
- Replace "KL"/"F" source badges in sidebar file list with a dot indicator showing which files are currently open in tabs
- Replace `window.confirm` for unsaved changes on tab close with a styled modal dialog (close without saving / save and close)
- Fix `saveCurrentFile` for keep-local articles that have no file path — now clears dirty flag without attempting file write

## Test plan
- [ ] Open multiple files and verify dots appear next to open files in sidebar
- [ ] Close a tab and verify the dot disappears from sidebar
- [ ] Edit a file, try closing its tab — verify custom dialog appears
- [ ] Click "Save and close" — verify file is saved and tab closes
- [ ] Click "Close without saving" — verify tab closes without saving
- [ ] Open a keep-local article, make edits, save — verify no error

🤖 Generated with [Claude Code](https://claude.com/claude-code)