### PR TITLE
feat: sidebar orders by activity, not opens

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2189,7 +2189,7 @@ checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
 name = "margin"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "dirs",
  "notify",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -84,7 +84,7 @@ function findTextInDoc(
 export default function App() {
   const { settings, setSetting } = useSettings();
   const doc = useDocument(settings.autosave);
-  const annotations = useAnnotations();
+  const annotations = useAnnotations(doc.refreshRecentDocs);
   const keepLocal = useKeepLocal();
   const search = useSearch();
   const [editor, setEditor] = useState<Editor | null>(null);

--- a/src/hooks/useAnnotations.ts
+++ b/src/hooks/useAnnotations.ts
@@ -30,7 +30,7 @@ export interface UseAnnotationsReturn {
   restoreFromCache: (highlights: Highlight[], marginNotes: MarginNote[]) => void;
 }
 
-export function useAnnotations(): UseAnnotationsReturn {
+export function useAnnotations(onMutate?: () => void): UseAnnotationsReturn {
   const [highlights, setHighlights] = useState<Highlight[]>([]);
   const [marginNotes, setMarginNotes] = useState<MarginNote[]>([]);
   const [isLoaded, setIsLoaded] = useState(false);
@@ -66,16 +66,18 @@ export function useAnnotations(): UseAnnotationsReturn {
         suffixContext: params.suffixContext,
       });
       setHighlights((prev) => [...prev, highlight]);
+      onMutate?.();
       return highlight;
     },
-    [],
+    [onMutate],
   );
 
   const deleteHighlight = useCallback(async (id: string) => {
     await invoke("delete_highlight", { id });
     setHighlights((prev) => prev.filter((h) => h.id !== id));
     setMarginNotes((prev) => prev.filter((n) => n.highlight_id !== id));
-  }, []);
+    onMutate?.();
+  }, [onMutate]);
 
   const createMarginNote = useCallback(
     async (highlightId: string, content: string): Promise<MarginNote> => {
@@ -84,9 +86,10 @@ export function useAnnotations(): UseAnnotationsReturn {
         content,
       });
       setMarginNotes((prev) => [...prev, note]);
+      onMutate?.();
       return note;
     },
-    [],
+    [onMutate],
   );
 
   const updateMarginNote = useCallback(
@@ -97,14 +100,16 @@ export function useAnnotations(): UseAnnotationsReturn {
           n.id === id ? { ...n, content, updated_at: Date.now() } : n,
         ),
       );
+      onMutate?.();
     },
-    [],
+    [onMutate],
   );
 
   const deleteMarginNote = useCallback(async (id: string) => {
     await invoke("delete_margin_note", { id });
     setMarginNotes((prev) => prev.filter((n) => n.id !== id));
-  }, []);
+    onMutate?.();
+  }, [onMutate]);
 
   const restoreFromCache = useCallback((cachedHighlights: Highlight[], cachedMarginNotes: MarginNote[]) => {
     setHighlights(cachedHighlights);


### PR DESCRIPTION
## Summary

- **Stop bumping `last_opened_at` on open** — clicking a doc in the sidebar no longer moves it to the top
- **Touch document on annotation CRUD** — backend updates `last_opened_at` when highlights or margin notes are created/updated/deleted
- **Refresh sidebar after mutations** — `useAnnotations` accepts an `onMutate` callback to re-fetch recent docs

## Test plan

- [ ] Open a doc — verify it does NOT jump to top of sidebar
- [ ] Add a highlight — verify doc moves to "Today"
- [ ] Add a margin note — same
- [ ] Delete a highlight — same
- [ ] Edit and Cmd+S — verify doc moves to "Today"

🤖 Generated with [Claude Code](https://claude.com/claude-code)