### PR TITLE
fix: motion audit critical fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,11 @@ pnpm tauri build      # Full desktop app bundle
 pnpm tsc --noEmit     # Type check without emitting
 ```
 
-No test framework is configured.
+**This is a Tauri desktop app, not a browser app.** `pnpm dev` starts the Vite dev server at localhost:1420 but only serves the frontend — no Rust backend, no SQLite, no Tauri commands. Always use `pnpm tauri dev` to run the actual app.
+
+**Frontend tests** use Vitest: `pnpm test` (single run), `pnpm test:watch` (watch mode). Test files live alongside source in `__tests__/` directories.
+
+**Backend tests** use Rust's built-in test framework: `cargo test` (from repo root or `src-tauri/`). Tests use in-memory SQLite — inner functions accept `&Connection` so they can be tested without the Tauri runtime. Covers annotations, documents, tabs, search, corrections, and migrations.
 
 ## Architecture
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2009,7 +2009,7 @@ checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
 name = "margin"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "dirs",
  "notify",

--- a/src-tauri/src/commands/annotations.rs
+++ b/src-tauri/src/commands/annotations.rs
@@ -1,5 +1,6 @@
 use crate::db::migrations::get_db;
 use crate::db::models::{Highlight, MarginNote};
+use rusqlite::Connection;
 use std::time::SystemTime;
 use uuid::Uuid;
 
@@ -10,7 +11,7 @@ fn now_millis() -> i64 {
         .as_millis() as i64
 }
 
-fn touch_document(conn: &rusqlite::Connection, document_id: &str) -> Result<(), String> {
+fn touch_document(conn: &Connection, document_id: &str) -> Result<(), String> {
     conn.execute(
         "UPDATE documents SET last_opened_at = ?1 WHERE id = ?2",
         rusqlite::params![now_millis(), document_id],
@@ -19,7 +20,7 @@ fn touch_document(conn: &rusqlite::Connection, document_id: &str) -> Result<(), 
     Ok(())
 }
 
-fn document_id_for_highlight(conn: &rusqlite::Connection, highlight_id: &str) -> Result<String, String> {
+fn document_id_for_highlight(conn: &Connection, highlight_id: &str) -> Result<String, String> {
     conn.query_row(
         "SELECT document_id FROM highlights WHERE id = ?1",
         rusqlite::params![highlight_id],
@@ -28,7 +29,7 @@ fn document_id_for_highlight(conn: &rusqlite::Connection, highlight_id: &str) ->
     .map_err(|e| e.to_string())
 }
 
-fn document_id_for_margin_note(conn: &rusqlite::Connection, note_id: &str) -> Result<String, String> {
+fn document_id_for_margin_note(conn: &Connection, note_id: &str) -> Result<String, String> {
     conn.query_row(
         "SELECT h.document_id FROM margin_notes mn JOIN highlights h ON mn.highlight_id = h.id WHERE mn.id = ?1",
         rusqlite::params![note_id],
@@ -37,7 +38,119 @@ fn document_id_for_margin_note(conn: &rusqlite::Connection, note_id: &str) -> Re
     .map_err(|e| e.to_string())
 }
 
-// === Highlights ===
+// === Inner functions (testable with &Connection) ===
+
+fn insert_highlight(
+    conn: &Connection,
+    id: &str,
+    document_id: &str,
+    color: &str,
+    text_content: &str,
+    from_pos: i64,
+    to_pos: i64,
+    prefix_context: Option<&str>,
+    suffix_context: Option<&str>,
+    now: i64,
+) -> Result<(), String> {
+    conn.execute(
+        "INSERT INTO highlights
+            (id, document_id, color, text_content, from_pos, to_pos,
+             prefix_context, suffix_context, created_at, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+        rusqlite::params![id, document_id, color, text_content, from_pos, to_pos, prefix_context, suffix_context, now, now],
+    )
+    .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+fn fetch_highlights(conn: &Connection, document_id: &str) -> Result<Vec<Highlight>, String> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, document_id, color, text_content, from_pos, to_pos,
+                    prefix_context, suffix_context, created_at, updated_at
+             FROM highlights
+             WHERE document_id = ?1
+             ORDER BY from_pos",
+        )
+        .map_err(|e| e.to_string())?;
+
+    let results = stmt
+        .query_map([document_id], |row| Highlight::from_row(row))
+        .map_err(|e| e.to_string())?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| e.to_string());
+    results
+}
+
+fn set_highlight_color(conn: &Connection, id: &str, color: &str, now: i64) -> Result<(), String> {
+    conn.execute(
+        "UPDATE highlights SET color = ?1, updated_at = ?2 WHERE id = ?3",
+        rusqlite::params![color, now, id],
+    )
+    .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+fn remove_highlight(conn: &Connection, id: &str) -> Result<(), String> {
+    conn.execute("DELETE FROM highlights WHERE id = ?1", rusqlite::params![id])
+        .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+fn insert_margin_note(
+    conn: &Connection,
+    id: &str,
+    highlight_id: &str,
+    content: &str,
+    now: i64,
+) -> Result<(), String> {
+    conn.execute(
+        "INSERT INTO margin_notes (id, highlight_id, content, created_at, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5)",
+        rusqlite::params![id, highlight_id, content, now, now],
+    )
+    .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+fn fetch_margin_notes(conn: &Connection, document_id: &str) -> Result<Vec<MarginNote>, String> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT mn.id, mn.highlight_id, mn.content, mn.created_at, mn.updated_at
+             FROM margin_notes mn
+             JOIN highlights h ON mn.highlight_id = h.id
+             WHERE h.document_id = ?1
+             ORDER BY h.from_pos",
+        )
+        .map_err(|e| e.to_string())?;
+
+    let results = stmt
+        .query_map([document_id], |row| MarginNote::from_row(row))
+        .map_err(|e| e.to_string())?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| e.to_string());
+    results
+}
+
+fn set_margin_note_content(conn: &Connection, id: &str, content: &str, now: i64) -> Result<(), String> {
+    conn.execute(
+        "UPDATE margin_notes SET content = ?1, updated_at = ?2 WHERE id = ?3",
+        rusqlite::params![content, now, id],
+    )
+    .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+fn remove_margin_note(conn: &Connection, id: &str) -> Result<(), String> {
+    conn.execute(
+        "DELETE FROM margin_notes WHERE id = ?1",
+        rusqlite::params![id],
+    )
+    .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+// === Tauri command handlers ===
 
 #[tauri::command]
 pub async fn create_highlight(
@@ -53,25 +166,12 @@ pub async fn create_highlight(
     let id = Uuid::new_v4().to_string();
     let now = now_millis();
 
-    conn.execute(
-        "INSERT INTO highlights
-            (id, document_id, color, text_content, from_pos, to_pos,
-             prefix_context, suffix_context, created_at, updated_at)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
-        rusqlite::params![
-            id,
-            document_id,
-            color,
-            text_content,
-            from_pos,
-            to_pos,
-            prefix_context,
-            suffix_context,
-            now,
-            now,
-        ],
-    )
-    .map_err(|e| e.to_string())?;
+    insert_highlight(
+        &conn, &id, &document_id, &color, &text_content,
+        from_pos, to_pos,
+        prefix_context.as_deref(), suffix_context.as_deref(),
+        now,
+    )?;
 
     touch_document(&conn, &document_id)?;
 
@@ -92,24 +192,7 @@ pub async fn create_highlight(
 #[tauri::command]
 pub async fn get_highlights(document_id: String) -> Result<Vec<Highlight>, String> {
     let conn = get_db()?;
-
-    let mut stmt = conn
-        .prepare(
-            "SELECT id, document_id, color, text_content, from_pos, to_pos,
-                    prefix_context, suffix_context, created_at, updated_at
-             FROM highlights
-             WHERE document_id = ?1
-             ORDER BY from_pos",
-        )
-        .map_err(|e| e.to_string())?;
-
-    let highlights = stmt
-        .query_map([&document_id], |row| Highlight::from_row(row))
-        .map_err(|e| e.to_string())?
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(|e| e.to_string())?;
-
-    Ok(highlights)
+    fetch_highlights(&conn, &document_id)
 }
 
 #[tauri::command]
@@ -117,11 +200,7 @@ pub async fn update_highlight_color(id: String, color: String) -> Result<(), Str
     let conn = get_db()?;
     let now = now_millis();
 
-    conn.execute(
-        "UPDATE highlights SET color = ?1, updated_at = ?2 WHERE id = ?3",
-        rusqlite::params![color, now, id],
-    )
-    .map_err(|e| e.to_string())?;
+    set_highlight_color(&conn, &id, &color, now)?;
 
     let doc_id = document_id_for_highlight(&conn, &id)?;
     touch_document(&conn, &doc_id)?;
@@ -134,16 +213,11 @@ pub async fn delete_highlight(id: String) -> Result<(), String> {
     let conn = get_db()?;
 
     let doc_id = document_id_for_highlight(&conn, &id)?;
-
-    conn.execute("DELETE FROM highlights WHERE id = ?1", rusqlite::params![id])
-        .map_err(|e| e.to_string())?;
-
+    remove_highlight(&conn, &id)?;
     touch_document(&conn, &doc_id)?;
 
     Ok(())
 }
-
-// === Margin Notes ===
 
 #[tauri::command]
 pub async fn create_margin_note(
@@ -154,12 +228,7 @@ pub async fn create_margin_note(
     let id = Uuid::new_v4().to_string();
     let now = now_millis();
 
-    conn.execute(
-        "INSERT INTO margin_notes (id, highlight_id, content, created_at, updated_at)
-         VALUES (?1, ?2, ?3, ?4, ?5)",
-        rusqlite::params![id, highlight_id, content, now, now],
-    )
-    .map_err(|e| e.to_string())?;
+    insert_margin_note(&conn, &id, &highlight_id, &content, now)?;
 
     let doc_id = document_id_for_highlight(&conn, &highlight_id)?;
     touch_document(&conn, &doc_id)?;
@@ -176,24 +245,7 @@ pub async fn create_margin_note(
 #[tauri::command]
 pub async fn get_margin_notes(document_id: String) -> Result<Vec<MarginNote>, String> {
     let conn = get_db()?;
-
-    let mut stmt = conn
-        .prepare(
-            "SELECT mn.id, mn.highlight_id, mn.content, mn.created_at, mn.updated_at
-             FROM margin_notes mn
-             JOIN highlights h ON mn.highlight_id = h.id
-             WHERE h.document_id = ?1
-             ORDER BY h.from_pos",
-        )
-        .map_err(|e| e.to_string())?;
-
-    let notes = stmt
-        .query_map([&document_id], |row| MarginNote::from_row(row))
-        .map_err(|e| e.to_string())?
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(|e| e.to_string())?;
-
-    Ok(notes)
+    fetch_margin_notes(&conn, &document_id)
 }
 
 #[tauri::command]
@@ -202,13 +254,7 @@ pub async fn update_margin_note(id: String, content: String) -> Result<(), Strin
     let now = now_millis();
 
     let doc_id = document_id_for_margin_note(&conn, &id)?;
-
-    conn.execute(
-        "UPDATE margin_notes SET content = ?1, updated_at = ?2 WHERE id = ?3",
-        rusqlite::params![content, now, id],
-    )
-    .map_err(|e| e.to_string())?;
-
+    set_margin_note_content(&conn, &id, &content, now)?;
     touch_document(&conn, &doc_id)?;
 
     Ok(())
@@ -219,15 +265,268 @@ pub async fn delete_margin_note(id: String) -> Result<(), String> {
     let conn = get_db()?;
 
     let doc_id = document_id_for_margin_note(&conn, &id)?;
-
-    conn.execute(
-        "DELETE FROM margin_notes WHERE id = ?1",
-        rusqlite::params![id],
-    )
-    .map_err(|e| e.to_string())?;
-
+    remove_margin_note(&conn, &id)?;
     touch_document(&conn, &doc_id)?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn schema_sql() -> &'static str {
+        "PRAGMA foreign_keys=ON;
+         CREATE TABLE documents (
+             id TEXT PRIMARY KEY,
+             source TEXT NOT NULL,
+             file_path TEXT,
+             keep_local_id TEXT,
+             title TEXT,
+             author TEXT,
+             url TEXT,
+             word_count INTEGER DEFAULT 0,
+             last_opened_at INTEGER NOT NULL,
+             created_at INTEGER NOT NULL,
+             UNIQUE(file_path),
+             UNIQUE(keep_local_id)
+         );
+         CREATE TABLE highlights (
+             id TEXT PRIMARY KEY,
+             document_id TEXT NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
+             color TEXT NOT NULL DEFAULT 'yellow',
+             text_content TEXT NOT NULL,
+             from_pos INTEGER NOT NULL,
+             to_pos INTEGER NOT NULL,
+             prefix_context TEXT,
+             suffix_context TEXT,
+             created_at INTEGER NOT NULL,
+             updated_at INTEGER NOT NULL
+         );
+         CREATE INDEX idx_highlights_document ON highlights(document_id);
+         CREATE TABLE margin_notes (
+             id TEXT PRIMARY KEY,
+             highlight_id TEXT NOT NULL REFERENCES highlights(id) ON DELETE CASCADE,
+             content TEXT NOT NULL,
+             created_at INTEGER NOT NULL,
+             updated_at INTEGER NOT NULL
+         );
+         CREATE INDEX idx_margin_notes_highlight ON margin_notes(highlight_id);"
+    }
+
+    fn setup_db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(schema_sql()).unwrap();
+        conn
+    }
+
+    fn insert_doc(conn: &Connection, id: &str) {
+        conn.execute(
+            "INSERT INTO documents (id, source, title, last_opened_at, created_at)
+             VALUES (?1, 'file', 'Test Doc', 1000, 1000)",
+            rusqlite::params![id],
+        )
+        .unwrap();
+    }
+
+    fn highlight_count(conn: &Connection) -> i64 {
+        conn.query_row("SELECT COUNT(*) FROM highlights", [], |r| r.get(0)).unwrap()
+    }
+
+    fn note_count(conn: &Connection) -> i64 {
+        conn.query_row("SELECT COUNT(*) FROM margin_notes", [], |r| r.get(0)).unwrap()
+    }
+
+    // === Highlight tests ===
+
+    #[test]
+    fn insert_and_fetch_highlights() {
+        let conn = setup_db();
+        insert_doc(&conn, "doc1");
+
+        insert_highlight(&conn, "h1", "doc1", "yellow", "hello world", 0, 11, Some("pre"), Some("suf"), 1000).unwrap();
+        insert_highlight(&conn, "h2", "doc1", "green", "second", 20, 26, None, None, 1001).unwrap();
+
+        let highlights = fetch_highlights(&conn, "doc1").unwrap();
+        assert_eq!(highlights.len(), 2);
+        assert_eq!(highlights[0].id, "h1");
+        assert_eq!(highlights[0].text_content, "hello world");
+        assert_eq!(highlights[0].prefix_context.as_deref(), Some("pre"));
+        assert_eq!(highlights[1].id, "h2");
+        assert_eq!(highlights[1].color, "green");
+    }
+
+    #[test]
+    fn fetch_highlights_ordered_by_from_pos() {
+        let conn = setup_db();
+        insert_doc(&conn, "doc1");
+
+        // Insert out of order
+        insert_highlight(&conn, "h2", "doc1", "yellow", "later", 50, 55, None, None, 1000).unwrap();
+        insert_highlight(&conn, "h1", "doc1", "yellow", "earlier", 10, 17, None, None, 1001).unwrap();
+
+        let highlights = fetch_highlights(&conn, "doc1").unwrap();
+        assert_eq!(highlights[0].from_pos, 10);
+        assert_eq!(highlights[1].from_pos, 50);
+    }
+
+    #[test]
+    fn fetch_highlights_scoped_to_document() {
+        let conn = setup_db();
+        insert_doc(&conn, "doc1");
+        insert_doc(&conn, "doc2");
+
+        insert_highlight(&conn, "h1", "doc1", "yellow", "in doc1", 0, 7, None, None, 1000).unwrap();
+        insert_highlight(&conn, "h2", "doc2", "yellow", "in doc2", 0, 7, None, None, 1000).unwrap();
+
+        let highlights = fetch_highlights(&conn, "doc1").unwrap();
+        assert_eq!(highlights.len(), 1);
+        assert_eq!(highlights[0].document_id, "doc1");
+    }
+
+    #[test]
+    fn update_highlight_color_changes_color_and_timestamp() {
+        let conn = setup_db();
+        insert_doc(&conn, "doc1");
+        insert_highlight(&conn, "h1", "doc1", "yellow", "text", 0, 4, None, None, 1000).unwrap();
+
+        set_highlight_color(&conn, "h1", "green", 2000).unwrap();
+
+        let highlights = fetch_highlights(&conn, "doc1").unwrap();
+        assert_eq!(highlights[0].color, "green");
+        assert_eq!(highlights[0].updated_at, 2000);
+        assert_eq!(highlights[0].created_at, 1000); // unchanged
+    }
+
+    #[test]
+    fn delete_highlight_removes_it() {
+        let conn = setup_db();
+        insert_doc(&conn, "doc1");
+        insert_highlight(&conn, "h1", "doc1", "yellow", "text", 0, 4, None, None, 1000).unwrap();
+        assert_eq!(highlight_count(&conn), 1);
+
+        remove_highlight(&conn, "h1").unwrap();
+        assert_eq!(highlight_count(&conn), 0);
+    }
+
+    #[test]
+    fn delete_highlight_cascades_to_margin_notes() {
+        let conn = setup_db();
+        insert_doc(&conn, "doc1");
+        insert_highlight(&conn, "h1", "doc1", "yellow", "text", 0, 4, None, None, 1000).unwrap();
+        insert_margin_note(&conn, "n1", "h1", "my note", 1000).unwrap();
+        assert_eq!(note_count(&conn), 1);
+
+        remove_highlight(&conn, "h1").unwrap();
+        assert_eq!(note_count(&conn), 0); // cascade
+    }
+
+    #[test]
+    fn delete_document_cascades_to_highlights_and_notes() {
+        let conn = setup_db();
+        insert_doc(&conn, "doc1");
+        insert_highlight(&conn, "h1", "doc1", "yellow", "text", 0, 4, None, None, 1000).unwrap();
+        insert_margin_note(&conn, "n1", "h1", "my note", 1000).unwrap();
+
+        conn.execute("DELETE FROM documents WHERE id = 'doc1'", []).unwrap();
+        assert_eq!(highlight_count(&conn), 0);
+        assert_eq!(note_count(&conn), 0);
+    }
+
+    // === Margin Note tests ===
+
+    #[test]
+    fn insert_and_fetch_margin_notes() {
+        let conn = setup_db();
+        insert_doc(&conn, "doc1");
+        insert_highlight(&conn, "h1", "doc1", "yellow", "text", 0, 4, None, None, 1000).unwrap();
+
+        insert_margin_note(&conn, "n1", "h1", "first note", 1000).unwrap();
+        insert_margin_note(&conn, "n2", "h1", "second note", 1001).unwrap();
+
+        let notes = fetch_margin_notes(&conn, "doc1").unwrap();
+        assert_eq!(notes.len(), 2);
+        assert_eq!(notes[0].content, "first note");
+        assert_eq!(notes[0].highlight_id, "h1");
+    }
+
+    #[test]
+    fn fetch_margin_notes_ordered_by_highlight_position() {
+        let conn = setup_db();
+        insert_doc(&conn, "doc1");
+        insert_highlight(&conn, "h2", "doc1", "yellow", "later", 50, 55, None, None, 1000).unwrap();
+        insert_highlight(&conn, "h1", "doc1", "yellow", "earlier", 10, 17, None, None, 1000).unwrap();
+
+        insert_margin_note(&conn, "n2", "h2", "note on later", 1000).unwrap();
+        insert_margin_note(&conn, "n1", "h1", "note on earlier", 1001).unwrap();
+
+        let notes = fetch_margin_notes(&conn, "doc1").unwrap();
+        assert_eq!(notes[0].content, "note on earlier");
+        assert_eq!(notes[1].content, "note on later");
+    }
+
+    #[test]
+    fn update_margin_note_changes_content_and_timestamp() {
+        let conn = setup_db();
+        insert_doc(&conn, "doc1");
+        insert_highlight(&conn, "h1", "doc1", "yellow", "text", 0, 4, None, None, 1000).unwrap();
+        insert_margin_note(&conn, "n1", "h1", "original", 1000).unwrap();
+
+        set_margin_note_content(&conn, "n1", "updated", 2000).unwrap();
+
+        let notes = fetch_margin_notes(&conn, "doc1").unwrap();
+        assert_eq!(notes[0].content, "updated");
+        assert_eq!(notes[0].updated_at, 2000);
+        assert_eq!(notes[0].created_at, 1000);
+    }
+
+    #[test]
+    fn delete_margin_note_removes_it() {
+        let conn = setup_db();
+        insert_doc(&conn, "doc1");
+        insert_highlight(&conn, "h1", "doc1", "yellow", "text", 0, 4, None, None, 1000).unwrap();
+        insert_margin_note(&conn, "n1", "h1", "note", 1000).unwrap();
+        assert_eq!(note_count(&conn), 1);
+
+        remove_margin_note(&conn, "n1").unwrap();
+        assert_eq!(note_count(&conn), 0);
+    }
+
+    #[test]
+    fn document_id_for_highlight_returns_correct_doc() {
+        let conn = setup_db();
+        insert_doc(&conn, "doc1");
+        insert_highlight(&conn, "h1", "doc1", "yellow", "text", 0, 4, None, None, 1000).unwrap();
+
+        assert_eq!(document_id_for_highlight(&conn, "h1").unwrap(), "doc1");
+    }
+
+    #[test]
+    fn document_id_for_margin_note_returns_correct_doc() {
+        let conn = setup_db();
+        insert_doc(&conn, "doc1");
+        insert_highlight(&conn, "h1", "doc1", "yellow", "text", 0, 4, None, None, 1000).unwrap();
+        insert_margin_note(&conn, "n1", "h1", "note", 1000).unwrap();
+
+        assert_eq!(document_id_for_margin_note(&conn, "n1").unwrap(), "doc1");
+    }
+
+    #[test]
+    fn empty_document_returns_no_highlights() {
+        let conn = setup_db();
+        insert_doc(&conn, "doc1");
+
+        let highlights = fetch_highlights(&conn, "doc1").unwrap();
+        assert!(highlights.is_empty());
+    }
+
+    #[test]
+    fn empty_document_returns_no_margin_notes() {
+        let conn = setup_db();
+        insert_doc(&conn, "doc1");
+
+        let notes = fetch_margin_notes(&conn, "doc1").unwrap();
+        assert!(notes.is_empty());
+    }
 }
 

--- a/src-tauri/src/commands/documents.rs
+++ b/src-tauri/src/commands/documents.rs
@@ -1,12 +1,11 @@
 use crate::db::migrations::get_db;
 use crate::db::models::Document;
+use rusqlite::Connection;
 use uuid::Uuid;
 
-#[tauri::command]
-pub async fn get_recent_documents(limit: Option<i64>) -> Result<Vec<Document>, String> {
-    let conn = get_db()?;
-    let limit = limit.unwrap_or(20);
+// === Inner functions (testable with &Connection) ===
 
+fn fetch_recent_documents(conn: &Connection, limit: i64) -> Result<Vec<Document>, String> {
     let mut stmt = conn
         .prepare(
             "SELECT id, source, file_path, keep_local_id, title, author, url,
@@ -17,20 +16,15 @@ pub async fn get_recent_documents(limit: Option<i64>) -> Result<Vec<Document>, S
         )
         .map_err(|e| e.to_string())?;
 
-    let docs = stmt
+    let results = stmt
         .query_map([limit], |row| Document::from_row(row))
         .map_err(|e| e.to_string())?
         .collect::<Result<Vec<_>, _>>()
-        .map_err(|e| e.to_string())?;
-
-    Ok(docs)
+        .map_err(|e| e.to_string());
+    results
 }
 
-#[tauri::command]
-pub async fn upsert_document(mut doc: Document) -> Result<Document, String> {
-    let conn = get_db()?;
-
-    // Look up existing document by file_path or keep_local_id to preserve annotation links
+fn upsert_document_inner(conn: &Connection, mut doc: Document) -> Result<Document, String> {
     let existing_id: Option<String> = if let Some(ref fp) = doc.file_path {
         conn.query_row(
             "SELECT id FROM documents WHERE file_path = ?1",
@@ -86,4 +80,163 @@ pub async fn upsert_document(mut doc: Document) -> Result<Document, String> {
     .map_err(|e| e.to_string())?;
 
     Ok(doc)
+}
+
+// === Tauri command handlers ===
+
+#[tauri::command]
+pub async fn get_recent_documents(limit: Option<i64>) -> Result<Vec<Document>, String> {
+    let conn = get_db()?;
+    fetch_recent_documents(&conn, limit.unwrap_or(20))
+}
+
+#[tauri::command]
+pub async fn upsert_document(doc: Document) -> Result<Document, String> {
+    let conn = get_db()?;
+    upsert_document_inner(&conn, doc)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn schema_sql() -> &'static str {
+        "CREATE TABLE documents (
+             id TEXT PRIMARY KEY,
+             source TEXT NOT NULL,
+             file_path TEXT,
+             keep_local_id TEXT,
+             title TEXT,
+             author TEXT,
+             url TEXT,
+             word_count INTEGER DEFAULT 0,
+             last_opened_at INTEGER NOT NULL,
+             created_at INTEGER NOT NULL,
+             UNIQUE(file_path),
+             UNIQUE(keep_local_id)
+         );"
+    }
+
+    fn setup_db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(schema_sql()).unwrap();
+        conn
+    }
+
+    fn make_doc(id: &str, source: &str, file_path: Option<&str>, keep_local_id: Option<&str>, last_opened_at: i64) -> Document {
+        Document {
+            id: id.to_string(),
+            source: source.to_string(),
+            file_path: file_path.map(String::from),
+            keep_local_id: keep_local_id.map(String::from),
+            title: Some("Test".to_string()),
+            author: None,
+            url: None,
+            word_count: 100,
+            last_opened_at,
+            created_at: 1000,
+        }
+    }
+
+    #[test]
+    fn upsert_inserts_new_document() {
+        let conn = setup_db();
+        let doc = make_doc("d1", "file", Some("/test.md"), None, 1000);
+        let result = upsert_document_inner(&conn, doc).unwrap();
+        assert_eq!(result.id, "d1");
+
+        let count: i64 = conn.query_row("SELECT COUNT(*) FROM documents", [], |r| r.get(0)).unwrap();
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn upsert_generates_id_when_empty() {
+        let conn = setup_db();
+        let doc = make_doc("", "file", Some("/test.md"), None, 1000);
+        let result = upsert_document_inner(&conn, doc).unwrap();
+        assert!(!result.id.is_empty());
+    }
+
+    #[test]
+    fn upsert_reuses_id_for_existing_file_path() {
+        let conn = setup_db();
+        let doc1 = make_doc("original-id", "file", Some("/test.md"), None, 1000);
+        upsert_document_inner(&conn, doc1).unwrap();
+
+        // Upsert with different id but same file_path should reuse original id
+        let doc2 = make_doc("new-id", "file", Some("/test.md"), None, 2000);
+        let result = upsert_document_inner(&conn, doc2).unwrap();
+        assert_eq!(result.id, "original-id");
+
+        let count: i64 = conn.query_row("SELECT COUNT(*) FROM documents", [], |r| r.get(0)).unwrap();
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn upsert_reuses_id_for_existing_keep_local_id() {
+        let conn = setup_db();
+        let doc1 = make_doc("original-id", "keep-local", None, Some("kl-123"), 1000);
+        upsert_document_inner(&conn, doc1).unwrap();
+
+        let doc2 = make_doc("new-id", "keep-local", None, Some("kl-123"), 2000);
+        let result = upsert_document_inner(&conn, doc2).unwrap();
+        assert_eq!(result.id, "original-id");
+    }
+
+    #[test]
+    fn upsert_updates_fields_on_conflict() {
+        let conn = setup_db();
+        let doc1 = make_doc("d1", "file", Some("/test.md"), None, 1000);
+        upsert_document_inner(&conn, doc1).unwrap();
+
+        let mut doc2 = make_doc("d1", "file", Some("/test.md"), None, 2000);
+        doc2.title = Some("Updated Title".to_string());
+        doc2.word_count = 500;
+        upsert_document_inner(&conn, doc2).unwrap();
+
+        let title: String = conn.query_row(
+            "SELECT title FROM documents WHERE id = 'd1'", [], |r| r.get(0)
+        ).unwrap();
+        assert_eq!(title, "Updated Title");
+
+        let wc: i64 = conn.query_row(
+            "SELECT word_count FROM documents WHERE id = 'd1'", [], |r| r.get(0)
+        ).unwrap();
+        assert_eq!(wc, 500);
+    }
+
+    #[test]
+    fn fetch_recent_documents_ordered_by_last_opened() {
+        let conn = setup_db();
+        upsert_document_inner(&conn, make_doc("d1", "file", Some("/a.md"), None, 1000)).unwrap();
+        upsert_document_inner(&conn, make_doc("d2", "file", Some("/b.md"), None, 3000)).unwrap();
+        upsert_document_inner(&conn, make_doc("d3", "file", Some("/c.md"), None, 2000)).unwrap();
+
+        let docs = fetch_recent_documents(&conn, 10).unwrap();
+        assert_eq!(docs.len(), 3);
+        assert_eq!(docs[0].id, "d2"); // most recent
+        assert_eq!(docs[1].id, "d3");
+        assert_eq!(docs[2].id, "d1"); // oldest
+    }
+
+    #[test]
+    fn fetch_recent_documents_respects_limit() {
+        let conn = setup_db();
+        for i in 0..5 {
+            upsert_document_inner(
+                &conn,
+                make_doc(&format!("d{i}"), "file", Some(&format!("/{i}.md")), None, i as i64),
+            ).unwrap();
+        }
+
+        let docs = fetch_recent_documents(&conn, 2).unwrap();
+        assert_eq!(docs.len(), 2);
+    }
+
+    #[test]
+    fn fetch_recent_documents_empty_table() {
+        let conn = setup_db();
+        let docs = fetch_recent_documents(&conn, 10).unwrap();
+        assert!(docs.is_empty());
+    }
 }

--- a/src-tauri/src/commands/tabs.rs
+++ b/src-tauri/src/commands/tabs.rs
@@ -1,4 +1,5 @@
 use crate::db::migrations::get_db;
+use rusqlite::Connection;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -10,10 +11,9 @@ pub struct PersistedTab {
     pub created_at: i64,
 }
 
-#[tauri::command]
-pub async fn get_open_tabs() -> Result<Vec<PersistedTab>, String> {
-    let conn = get_db()?;
+// === Inner functions (testable with &Connection) ===
 
+fn fetch_open_tabs(conn: &Connection) -> Result<Vec<PersistedTab>, String> {
     let mut stmt = conn
         .prepare(
             "SELECT id, document_id, tab_order, is_active, created_at
@@ -22,7 +22,7 @@ pub async fn get_open_tabs() -> Result<Vec<PersistedTab>, String> {
         )
         .map_err(|e| e.to_string())?;
 
-    let tabs = stmt
+    let results = stmt
         .query_map([], |row| {
             Ok(PersistedTab {
                 id: row.get("id")?,
@@ -34,15 +34,11 @@ pub async fn get_open_tabs() -> Result<Vec<PersistedTab>, String> {
         })
         .map_err(|e| e.to_string())?
         .collect::<Result<Vec<_>, _>>()
-        .map_err(|e| e.to_string())?;
-
-    Ok(tabs)
+        .map_err(|e| e.to_string());
+    results
 }
 
-#[tauri::command]
-pub async fn save_open_tabs(tabs: Vec<PersistedTab>) -> Result<(), String> {
-    let conn = get_db()?;
-
+fn persist_open_tabs(conn: &Connection, tabs: &[PersistedTab]) -> Result<(), String> {
     let tx = conn.unchecked_transaction().map_err(|e| e.to_string())?;
 
     tx.execute("DELETE FROM open_tabs", [])
@@ -55,7 +51,7 @@ pub async fn save_open_tabs(tabs: Vec<PersistedTab>) -> Result<(), String> {
         )
         .map_err(|e| e.to_string())?;
 
-    for tab in &tabs {
+    for tab in tabs {
         stmt.execute(rusqlite::params![
             tab.id,
             tab.document_id,
@@ -70,4 +66,156 @@ pub async fn save_open_tabs(tabs: Vec<PersistedTab>) -> Result<(), String> {
     tx.commit().map_err(|e| e.to_string())?;
 
     Ok(())
+}
+
+// === Tauri command handlers ===
+
+#[tauri::command]
+pub async fn get_open_tabs() -> Result<Vec<PersistedTab>, String> {
+    let conn = get_db()?;
+    fetch_open_tabs(&conn)
+}
+
+#[tauri::command]
+pub async fn save_open_tabs(tabs: Vec<PersistedTab>) -> Result<(), String> {
+    let conn = get_db()?;
+    persist_open_tabs(&conn, &tabs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn schema_sql() -> &'static str {
+        "CREATE TABLE documents (
+             id TEXT PRIMARY KEY,
+             source TEXT NOT NULL,
+             file_path TEXT,
+             keep_local_id TEXT,
+             title TEXT,
+             author TEXT,
+             url TEXT,
+             word_count INTEGER DEFAULT 0,
+             last_opened_at INTEGER NOT NULL,
+             created_at INTEGER NOT NULL,
+             UNIQUE(file_path),
+             UNIQUE(keep_local_id)
+         );
+         CREATE TABLE open_tabs (
+             id TEXT PRIMARY KEY,
+             document_id TEXT NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
+             tab_order INTEGER NOT NULL,
+             is_active INTEGER NOT NULL DEFAULT 0,
+             created_at INTEGER NOT NULL
+         );"
+    }
+
+    fn setup_db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("PRAGMA foreign_keys=ON;").unwrap();
+        conn.execute_batch(schema_sql()).unwrap();
+        conn
+    }
+
+    fn insert_doc(conn: &Connection, id: &str) {
+        conn.execute(
+            "INSERT INTO documents (id, source, title, last_opened_at, created_at)
+             VALUES (?1, 'file', 'Test', 1000, 1000)",
+            rusqlite::params![id],
+        )
+        .unwrap();
+    }
+
+    fn make_tab(id: &str, doc_id: &str, order: i64, active: bool) -> PersistedTab {
+        PersistedTab {
+            id: id.to_string(),
+            document_id: doc_id.to_string(),
+            tab_order: order,
+            is_active: active,
+            created_at: 1000,
+        }
+    }
+
+    #[test]
+    fn save_and_fetch_tabs() {
+        let conn = setup_db();
+        insert_doc(&conn, "doc1");
+        insert_doc(&conn, "doc2");
+
+        let tabs = vec![
+            make_tab("t1", "doc1", 0, true),
+            make_tab("t2", "doc2", 1, false),
+        ];
+        persist_open_tabs(&conn, &tabs).unwrap();
+
+        let fetched = fetch_open_tabs(&conn).unwrap();
+        assert_eq!(fetched.len(), 2);
+        assert_eq!(fetched[0].id, "t1");
+        assert!(fetched[0].is_active);
+        assert_eq!(fetched[1].id, "t2");
+        assert!(!fetched[1].is_active);
+    }
+
+    #[test]
+    fn fetch_tabs_ordered_by_tab_order() {
+        let conn = setup_db();
+        insert_doc(&conn, "doc1");
+        insert_doc(&conn, "doc2");
+
+        let tabs = vec![
+            make_tab("t2", "doc2", 5, false),
+            make_tab("t1", "doc1", 1, true),
+        ];
+        persist_open_tabs(&conn, &tabs).unwrap();
+
+        let fetched = fetch_open_tabs(&conn).unwrap();
+        assert_eq!(fetched[0].tab_order, 1);
+        assert_eq!(fetched[1].tab_order, 5);
+    }
+
+    #[test]
+    fn save_tabs_replaces_existing() {
+        let conn = setup_db();
+        insert_doc(&conn, "doc1");
+        insert_doc(&conn, "doc2");
+
+        persist_open_tabs(&conn, &[make_tab("t1", "doc1", 0, true)]).unwrap();
+        assert_eq!(fetch_open_tabs(&conn).unwrap().len(), 1);
+
+        // Replace with different tabs
+        persist_open_tabs(&conn, &[
+            make_tab("t2", "doc2", 0, true),
+            make_tab("t3", "doc1", 1, false),
+        ]).unwrap();
+
+        let fetched = fetch_open_tabs(&conn).unwrap();
+        assert_eq!(fetched.len(), 2);
+        assert_eq!(fetched[0].id, "t2");
+    }
+
+    #[test]
+    fn save_empty_tabs_clears_all() {
+        let conn = setup_db();
+        insert_doc(&conn, "doc1");
+
+        persist_open_tabs(&conn, &[make_tab("t1", "doc1", 0, true)]).unwrap();
+        assert_eq!(fetch_open_tabs(&conn).unwrap().len(), 1);
+
+        persist_open_tabs(&conn, &[]).unwrap();
+        assert!(fetch_open_tabs(&conn).unwrap().is_empty());
+    }
+
+    #[test]
+    fn bool_roundtrip_for_is_active() {
+        let conn = setup_db();
+        insert_doc(&conn, "doc1");
+
+        persist_open_tabs(&conn, &[make_tab("t1", "doc1", 0, true)]).unwrap();
+        let fetched = fetch_open_tabs(&conn).unwrap();
+        assert!(fetched[0].is_active);
+
+        persist_open_tabs(&conn, &[make_tab("t1", "doc1", 0, false)]).unwrap();
+        let fetched = fetch_open_tabs(&conn).unwrap();
+        assert!(!fetched[0].is_active);
+    }
 }

--- a/src/components/editor/ExportAnnotationsPopover.tsx
+++ b/src/components/editor/ExportAnnotationsPopover.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, useRef } from "react";
 import type { ExportResult } from "@/types/export";
+import { useAnimatedPresence } from "@/hooks/useAnimatedPresence";
 
 interface ExportAnnotationsPopoverProps {
   isOpen: boolean;
@@ -18,6 +19,7 @@ export function ExportAnnotationsPopover({
 }: ExportAnnotationsPopoverProps) {
   const [result, setResult] = useState<ExportResult | null>(null);
   const [exporting, setExporting] = useState(false);
+  const { isMounted, isVisible } = useAnimatedPresence(isOpen, 200);
 
   // Reset state when popover opens
   useEffect(() => {
@@ -67,7 +69,7 @@ export function ExportAnnotationsPopover({
     return () => { cancelled = true; };
   }, [isOpen]);
 
-  if (!isOpen) return null;
+  if (!isMounted) return null;
 
   return (
     <div
@@ -87,6 +89,8 @@ export function ExportAnnotationsPopover({
           position: "absolute",
           inset: 0,
           backgroundColor: "rgba(0, 0, 0, 0.3)",
+          opacity: isVisible ? 1 : 0,
+          transition: `opacity ${isVisible ? "200ms var(--ease-entrance)" : "150ms var(--ease-exit)"}`,
         }}
       />
 
@@ -103,6 +107,11 @@ export function ExportAnnotationsPopover({
           minWidth: "min(320px, calc(100vw - 32px))",
           maxWidth: "min(400px, calc(100vw - 32px))",
           boxShadow: "0 8px 32px rgba(0, 0, 0, 0.2)",
+          opacity: isVisible ? 1 : 0,
+          transform: isVisible ? "scale(1) translateY(0)" : "scale(0.97) translateY(4px)",
+          transition: isVisible
+            ? "opacity 200ms var(--ease-entrance), transform 200ms var(--ease-entrance)"
+            : "opacity 150ms var(--ease-exit), transform 150ms var(--ease-exit)",
         }}
       >
         {/* Close button */}

--- a/src/components/editor/HighlightThread.tsx
+++ b/src/components/editor/HighlightThread.tsx
@@ -12,6 +12,7 @@ interface HighlightThreadProps {
   onClose: () => void;
   anchorRect: DOMRect | null;
   autoFocusNew?: boolean;
+  isVisible: boolean;
 }
 
 function formatTimeAgo(timestamp: number): string {
@@ -137,40 +138,27 @@ export function HighlightThread({
   onClose,
   anchorRect,
   autoFocusNew,
+  isVisible,
 }: HighlightThreadProps) {
   const [newNoteValue, setNewNoteValue] = useState("");
-  const [isVisible, setIsVisible] = useState(false);
-  const [isClosing, setIsClosing] = useState(false);
   const popoverRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const previousFocusRef = useRef<Element | null>(null);
 
-  // Save previous focus and animate in
+  // Save previous focus on mount
   useEffect(() => {
     previousFocusRef.current = document.activeElement;
-    requestAnimationFrame(() => setIsVisible(true));
-  }, []);
-
-  // Cleanup close timer
-  useEffect(() => {
     return () => {
-      if (closeTimerRef.current !== null) clearTimeout(closeTimerRef.current);
+      // Restore focus on unmount
+      if (previousFocusRef.current instanceof HTMLElement) {
+        previousFocusRef.current.focus();
+      }
     };
   }, []);
 
   const handleClose = useCallback(() => {
-    if (isClosing) return;
-    setIsClosing(true);
-    setIsVisible(false);
-    closeTimerRef.current = setTimeout(() => {
-      // Restore focus to previously focused element
-      if (previousFocusRef.current instanceof HTMLElement) {
-        previousFocusRef.current.focus();
-      }
-      onClose();
-    }, 200);
-  }, [isClosing, onClose]);
+    onClose();
+  }, [onClose]);
 
   // Auto-focus the new note textarea when opening from Note button
   useEffect(() => {
@@ -274,6 +262,7 @@ export function HighlightThread({
         opacity: isVisible ? 1 : 0,
         transform: isVisible ? "translateY(0)" : "translateY(100%)",
         transformOrigin: "bottom center",
+        pointerEvents: isVisible ? "auto" : "none",
         transition: isVisible
           ? "opacity 200ms cubic-bezier(0.16, 1, 0.3, 1), transform 200ms cubic-bezier(0.16, 1, 0.3, 1)"
           : "opacity 150ms cubic-bezier(0.4, 0, 1, 1), transform 150ms cubic-bezier(0.4, 0, 1, 1)",
@@ -283,6 +272,7 @@ export function HighlightThread({
         opacity: isVisible ? 1 : 0,
         transform: isVisible ? "scale(1)" : "scale(0.97)",
         transformOrigin: "left top",
+        pointerEvents: isVisible ? "auto" : "none",
         transition: isVisible
           ? "opacity 200ms cubic-bezier(0.16, 1, 0.3, 1), transform 200ms cubic-bezier(0.16, 1, 0.3, 1)"
           : "opacity 150ms cubic-bezier(0.4, 0, 1, 1), transform 150ms cubic-bezier(0.4, 0, 1, 1)",

--- a/src/components/editor/Reader.tsx
+++ b/src/components/editor/Reader.tsx
@@ -72,15 +72,16 @@ export function Reader({ content, onUpdate, isLoading, onEditorReady }: ReaderPr
     isExternalUpdate.current = false;
   }, [content, editor]);
 
-  if (isLoading) {
-    return (
-      <div className="reader-content" style={{ opacity: 0.5 }}>
-        <EditorContent editor={editor} />
-      </div>
-    );
-  }
-
-  return <EditorContent editor={editor} />;
+  return (
+    <div
+      style={{
+        opacity: isLoading ? 0.5 : 1,
+        transition: isLoading ? "none" : "opacity 200ms var(--ease-entrance)",
+      }}
+    >
+      <EditorContent editor={editor} />
+    </div>
+  );
 }
 
 export default Reader;

--- a/src/components/layout/SettingsModal.tsx
+++ b/src/components/layout/SettingsModal.tsx
@@ -3,6 +3,7 @@ import { writeText } from "@tauri-apps/plugin-clipboard-manager";
 import type { Settings } from "@/hooks/useSettings";
 import { getAllCorrections, getCorrectionsCount } from "@/lib/tauri-commands";
 import { formatStyleMemory } from "@/lib/export-annotations";
+import { useAnimatedPresence } from "@/hooks/useAnimatedPresence";
 
 interface SettingsModalProps {
   isOpen: boolean;
@@ -289,6 +290,8 @@ export function SettingsModal({
   settings,
   setSetting,
 }: SettingsModalProps) {
+  const { isMounted, isVisible } = useAnimatedPresence(isOpen, 200);
+
   // Escape to close
   useEffect(() => {
     if (!isOpen) return;
@@ -302,7 +305,7 @@ export function SettingsModal({
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [isOpen, onClose]);
 
-  if (!isOpen) return null;
+  if (!isMounted) return null;
 
   return (
     <div
@@ -322,6 +325,8 @@ export function SettingsModal({
           position: "absolute",
           inset: 0,
           backgroundColor: "rgba(0, 0, 0, 0.3)",
+          opacity: isVisible ? 1 : 0,
+          transition: `opacity ${isVisible ? "200ms var(--ease-entrance)" : "150ms var(--ease-exit)"}`,
         }}
       />
 
@@ -340,6 +345,11 @@ export function SettingsModal({
           overflowY: "auto",
           boxShadow: "0 8px 32px rgba(0, 0, 0, 0.2)",
           fontFamily: "'Inter', system-ui, sans-serif",
+          opacity: isVisible ? 1 : 0,
+          transform: isVisible ? "scale(1) translateY(0)" : "scale(0.97) translateY(4px)",
+          transition: isVisible
+            ? "opacity 200ms var(--ease-entrance), transform 200ms var(--ease-entrance)"
+            : "opacity 150ms var(--ease-exit), transform 150ms var(--ease-exit)",
         }}
       >
         {/* Header */}


### PR DESCRIPTION
## Summary
- **Reader loading flicker**: single stable wrapper div with opacity transition instead of two JSX branches that caused mount/unmount flicker
- **Empty state → content crossfade**: `useAnimatedPresence` for empty state exit + reader grid entrance animation, both render simultaneously during transition
- **HighlightThread unmount race**: lift animation ownership to parent via `useAnimatedPresence` + `lastHighlightRef` — fixes exit animation on tab switch, Escape, and highlight delete
- **Export button pop**: always-rendered with opacity/pointer-events, no layout shift on first highlight
- **Bonus**: animated transitions for ExportAnnotationsPopover, SettingsModal, Sidebar tab content + search dropdown
- **Rust tests**: expanded coverage for annotations, documents, search, tabs commands
- **CLAUDE.md**: documented Vitest + cargo test frameworks

## Test plan
- [ ] Open a document → reader fades in smoothly (no flicker)
- [ ] Open first document from empty state → Poe quote fades out, content fades in
- [ ] Close all tabs → return to empty state, reopen → entrance animation replays
- [ ] Create a highlight → export button fades in (no layout jump)
- [ ] Open highlight thread → close via Escape → animates out
- [ ] Switch tabs with thread open → animates out (no instant vanish)
- [ ] Delete a highlight from the thread → thread animates out
- [ ] Open/close Settings modal → animated entrance/exit
- [ ] Open/close Export popover → animated entrance/exit
- [ ] Switch sidebar tabs (Files/Articles) → content crossfades
- [ ] `pnpm tsc --noEmit` clean
- [ ] `cargo test` — 48 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)