### PR TITLE
refactor: remove separate articles tab from sidebar

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,7 +24,6 @@ import { formatAnnotationsMarkdown, getExtendedContext } from "@/lib/export-anno
 import { readFile, drainPendingOpenFiles } from "@/lib/tauri-commands";
 import { listen } from "@tauri-apps/api/event";
 
-import type { KeepLocalItem } from "@/types/keep-local";
 import type { Document } from "@/types/document";
 import type { CorrectionInput } from "@/types/annotations";
 import type { ExportResult } from "@/types/export";
@@ -812,39 +811,6 @@ export default function App() {
     [doc, keepLocal, tabsHook]
   );
 
-  // Open a keep-local article
-  const handleSelectKeepLocalItem = useCallback(
-    async (item: KeepLocalItem, newTab: boolean) => {
-      openAsNewTabRef.current = newTab;
-      tabsHook.snapshotActive();
-      try {
-        const markdown = await keepLocal.getContent(item.id);
-        const now = Date.now();
-
-        const docRecord: Document = {
-          id: crypto.randomUUID(),
-          source: "keep-local",
-          file_path: null,
-          keep_local_id: item.id,
-          title: item.title ?? "Untitled",
-          author: item.author ?? null,
-          url: item.url,
-          word_count: item.wordCount,
-          last_opened_at: now,
-          created_at: now,
-        };
-
-        await doc.openKeepLocalArticle(docRecord, markdown);
-        if (doc.currentDoc) {
-          void search.indexDocument(doc.currentDoc.id, doc.currentDoc.title ?? "Untitled", markdown);
-        }
-      } catch (err) {
-        console.error("Failed to open keep-local article:", err);
-      }
-    },
-    [keepLocal, doc, search]
-  );
-
   return (
     <AppShell
       onOpenSettings={() => setShowSettings(true)}
@@ -853,8 +819,6 @@ export default function App() {
       onOpenFile={doc.openFile}
       onSelectRecentDoc={handleSelectRecentDoc}
       isDirty={doc.isDirty}
-      keepLocal={keepLocal}
-      onSelectKeepLocalItem={handleSelectKeepLocalItem}
       search={search}
       hasAnnotations={annotations.isLoaded && annotations.highlights.length > 0}
       onExport={() => setShowExportPopover(true)}

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -4,10 +4,8 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import { Menu01Icon, Download01Icon } from "@hugeicons/core-free-icons";
 import type { Document } from "@/types/document";
 import type { Tab } from "@/types/tab";
-import type { KeepLocalItem } from "@/types/keep-local";
 import { Sidebar } from "@/components/layout/Sidebar";
 import { TabBar } from "@/components/layout/TabBar";
-import type { useKeepLocal } from "@/hooks/useKeepLocal";
 import type { useSearch } from "@/hooks/useSearch";
 
 interface AppShellProps {
@@ -18,8 +16,6 @@ interface AppShellProps {
   onOpenFile: () => void;
   onSelectRecentDoc: (doc: Document, newTab: boolean) => void;
   isDirty: boolean;
-  keepLocal: ReturnType<typeof useKeepLocal>;
-  onSelectKeepLocalItem: (item: KeepLocalItem, newTab: boolean) => void;
   search: ReturnType<typeof useSearch>;
   hasAnnotations?: boolean;
   onExport?: () => void;
@@ -44,8 +40,6 @@ export function AppShell({
   onOpenFile,
   onSelectRecentDoc,
   isDirty: _isDirty,
-  keepLocal,
-  onSelectKeepLocalItem,
   search,
   hasAnnotations,
   onExport,
@@ -226,12 +220,6 @@ export function AppShell({
           isSearching={search.isSearching}
           onOpenFilePath={(path, newTab) => { onOpenFilePath(path, newTab); closeSidebar(); }}
           onRenameFile={onRenameFile}
-          keepLocalItems={keepLocal.items}
-          keepLocalIsOnline={keepLocal.isOnline}
-          keepLocalIsLoading={keepLocal.isLoading}
-          keepLocalQuery={keepLocal.query}
-          onKeepLocalSearch={keepLocal.search}
-          onSelectKeepLocalItem={(item, newTab) => { onSelectKeepLocalItem(item, newTab); closeSidebar(); }}
           onOpenSettings={onOpenSettings}
           tabs={tabs}
         />
@@ -377,7 +365,7 @@ export function AppShell({
                     letterSpacing: "-0.01em",
                   }}
                 >
-                  Open a file or select an article to start reading
+                  Open a file to start reading
                 </p>
                 <p
                   className="mt-2 opacity-50"


### PR DESCRIPTION
## Summary
- Removes the Files/Articles tab switcher from the sidebar
- Sidebar now shows a single unified list of recent documents
- Keep-local articles previously opened still appear in recent docs and can be reopened
- `useKeepLocal` hook retained for tab restoration of cached articles

## Test plan
- [x] TypeScript compiles cleanly
- [x] All 24 Vitest tests pass
- [x] Verified in `pnpm tauri dev` — sidebar shows search + recent docs, no tab bar
- [ ] Open a previously-opened keep-local article from recent docs (should still work)
- [ ] Verify search works without the tab context

🤖 Generated with [Claude Code](https://claude.com/claude-code)