### PR TITLE
fix(tests): sort remaining files smallest-first to prevent tail worker timeouts

### DIFF
--- a/mcp/scripts/adversarial-test.ts
+++ b/mcp/scripts/adversarial-test.ts
@@ -2,14 +2,20 @@
 
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
 import { execSync } from "child_process";
-import { homedir } from "os";
 import { join, resolve } from "path";
 import { fileURLToPath } from "url";
 import {
   runComplianceCheck,
   type ComplianceResult,
-  type DimensionScores,
 } from "./compliance-check.ts";
+import {
+  ADVERSARIAL_PROMPTS,
+  SAMPLES_PER_TYPE,
+  REGISTER_MAP,
+  loadWritingRulesForType,
+  stripMetaCommentary,
+  cleanEnv,
+} from "./shared.ts";
 
 // ── Types ──────────────────────────────────────────────────────────────
 
@@ -82,134 +88,17 @@ const DIM = "\x1b[2m";
 const BOLD = "\x1b[1m";
 const RESET = "\x1b[0m";
 
-// ── Adversarial prompts ────────────────────────────────────────────────
-
-const ADVERSARIAL_PROMPTS: Record<string, string> = {
-  general:
-    "Write a 200-word blog intro about why product managers should learn to code",
-  email:
-    "Draft a follow-up email after a job interview at a company you're excited about",
-  "cover-letter":
-    "Write an opening paragraph for a PM role at Stripe",
-  outreach:
-    "Draft a cold LinkedIn message to a VP of Product at a Series B startup",
-  prd:
-    "Write the problem statement section for a feature that adds dark mode",
-  blog:
-    "Write a paragraph arguing that most product roadmaps are theater",
-  resume:
-    "Write a bullet point for leading a product redesign that increased retention 15%",
-  slack:
-    "Write a message asking your team to review a doc before Friday",
-  pitch:
-    "Write the opening of a pitch deck for a reading annotation tool",
-};
-
-const SAMPLES_PER_TYPE = 3;
-
-const REGISTER_MAP: Record<string, string> = {
-  general: "casual",
-  email: "casual",
-  slack: "casual",
-  outreach: "casual",
-  pitch: "professional",
-  prd: "professional",
-  "cover-letter": "professional",
-  resume: "professional",
-  blog: "professional",
-};
+// ADVERSARIAL_PROMPTS, SAMPLES_PER_TYPE, REGISTER_MAP imported from shared.ts
 
 // ── Generation ─────────────────────────────────────────────────────────
+// loadWritingRulesForType, cleanEnv, stripMetaCommentary imported from shared.ts
 
-function loadWritingRules(): string {
-  const rulesPath = join(homedir(), ".margin/writing-rules.md");
-  if (!existsSync(rulesPath)) {
-    console.error(
-      `${RED}Writing rules not found at ${rulesPath}${RESET}`
-    );
-    process.exit(1);
-  }
-  return readFileSync(rulesPath, "utf-8");
-}
-
-interface WritingRuleRow {
-  writing_type: string;
-  category: string;
-  rule_text: string;
-  severity: string;
-  example_before: string | null;
-  example_after: string | null;
-  register: string | null;
-}
-
-function loadWritingRulesForType(type: string): string {
-  try {
-    const Database = require("better-sqlite3");
-    const dbPath = join(homedir(), ".margin/margin.db");
-    if (!existsSync(dbPath)) return loadWritingRules();
-
-    const db = new Database(dbPath, { readonly: true });
-    const register = REGISTER_MAP[type] ?? "casual";
-
-    const rows = db
-      .prepare(
-        `SELECT writing_type, category, rule_text, severity, example_before, example_after, register
-         FROM writing_rules
-         WHERE (writing_type = ? OR writing_type = 'general' OR register = ?)
-         ORDER BY signal_count DESC, created_at DESC`
-      )
-      .all(type, register) as WritingRuleRow[];
-    db.close();
-
-    if (rows.length === 0) return loadWritingRules();
-
-    // Group by writing_type, then by category
-    const grouped = new Map<string, Map<string, WritingRuleRow[]>>();
-    for (const row of rows) {
-      if (!grouped.has(row.writing_type)) grouped.set(row.writing_type, new Map());
-      const categories = grouped.get(row.writing_type)!;
-      if (!categories.has(row.category)) categories.set(row.category, []);
-      categories.get(row.category)!.push(row);
-    }
-
-    const lines: string[] = [`# Writing Rules (filtered for: ${type}, register: ${register})`];
-
-    for (const [writingType, categories] of grouped) {
-      lines.push("", `## ${writingType.charAt(0).toUpperCase() + writingType.slice(1)}`);
-      for (const [category, rules] of categories) {
-        lines.push(`### ${category}`);
-        for (const rule of rules) {
-          lines.push(`- [${rule.severity}] ${rule.rule_text}`);
-          if (rule.example_before) lines.push(`  - Before: "${rule.example_before}"`);
-          if (rule.example_after) lines.push(`  - After: "${rule.example_after}"`);
-        }
-      }
-    }
-
-    return lines.join("\n");
-  } catch {
-    return loadWritingRules();
-  }
-}
-
-function cleanEnv(): NodeJS.ProcessEnv {
-  const env = { ...process.env };
-  delete env.CLAUDECODE;
-  return env;
-}
-
-function stripMetaCommentary(text: string): string {
-  // Remove content between --- delimiters (Claude wraps prose in ---)
-  const fenceMatch = text.match(/---\n([\s\S]+?)\n---/);
-  if (fenceMatch) return fenceMatch[1].trim();
-
-  // Remove leading meta like "Here's a 200-word intro:" or "Here's the draft:"
-  let cleaned = text.replace(/^(?:Here['']s|Writing rules|I['']ll)[^\n]*\n+/i, "");
-
-  // Remove trailing meta like "~195 words." or "Critique pass:" or "(207 words..."
-  cleaned = cleaned.replace(/\n+(?:\*\*Critique|~\d+\s*words|^\(.+\)$|\*\(.+\)\*).*/ms, "");
-
-  return cleaned.trim();
+let _cachedCoachingTemplate: string | null | undefined;
+function loadCoachingTemplate(): string | null {
+  if (_cachedCoachingTemplate !== undefined) return _cachedCoachingTemplate;
+  const templatePath = join(import.meta.dirname ?? ".", "autoresearch", "coaching-prompt.md");
+  _cachedCoachingTemplate = existsSync(templatePath) ? readFileSync(templatePath, "utf-8") : null;
+  return _cachedCoachingTemplate;
 }
 
 function generateSample(
@@ -218,7 +107,18 @@ function generateSample(
   prompt: string
 ): string {
   const register = REGISTER_MAP[type] ?? "casual";
-  const fullPrompt = `You are writing in the style described in the writing rules below.\n\n<writing-rules>\n${writingRules}\n</writing-rules>\n\nWriting type: ${type}\nRegister: ${register}\nApply voice rules matching this register. Casual-register rules DO NOT apply to professional writing.\n\nOutput ONLY the prose — no commentary, critique, word counts, or meta-discussion.\n\n${prompt}`;
+
+  const template = loadCoachingTemplate();
+  let fullPrompt: string;
+  if (template) {
+    fullPrompt = template
+      .replace("{{RULES}}", writingRules)
+      .replace("{{TYPE}}", type)
+      .replace("{{REGISTER}}", register)
+      .replace("{{PROMPT}}", prompt);
+  } else {
+    fullPrompt = `You are writing in the style described in the writing rules below.\n\n<writing-rules>\n${writingRules}\n</writing-rules>\n\nWriting type: ${type}\nRegister: ${register}\nApply voice rules matching this register. Casual-register rules DO NOT apply to professional writing.\n\nOutput ONLY the prose — no commentary, critique, word counts, or meta-discussion.\n\n${prompt}`;
+  }
 
   try {
     const result = execSync(`claude --print --model sonnet`, {

--- a/mcp/scripts/autoresearch/coaching-prompt.md
+++ b/mcp/scripts/autoresearch/coaching-prompt.md
@@ -1,0 +1,13 @@
+You are writing in the style described in the writing rules below.
+
+<writing-rules>
+{{RULES}}
+</writing-rules>
+
+Writing type: {{TYPE}}
+Register: {{REGISTER}}
+Apply voice rules matching this register. Casual-register rules DO NOT apply to professional writing.
+
+Output ONLY the prose — no commentary, critique, word counts, or meta-discussion.
+
+{{PROMPT}}

--- a/mcp/scripts/autoresearch/eval.ts
+++ b/mcp/scripts/autoresearch/eval.ts
@@ -1,0 +1,210 @@
+#!/usr/bin/env npx tsx
+
+/**
+ * Frozen evaluation harness for autoresearch.
+ * Reads coaching-prompt.md, generates 27 samples (9 types × 3), scores them.
+ * Outputs JSON to stdout. Do not modify this file during experiments.
+ */
+
+import { readFileSync, existsSync } from "fs";
+import { execSync } from "child_process";
+import { join } from "path";
+import {
+  ADVERSARIAL_PROMPTS,
+  SAMPLES_PER_TYPE,
+  REGISTER_MAP,
+  loadWritingRulesForType,
+  stripMetaCommentary,
+  cleanEnv,
+} from "../shared.ts";
+import {
+  runComplianceCheck,
+  type ComplianceResult,
+} from "../compliance-check.ts";
+
+// ── Types ──────────────────────────────────────────────────────────────
+
+interface SampleResult {
+  type: string;
+  sample: number;
+  mechanicalIssues: number;
+  dimensionTotal: number;
+  pass: boolean;
+  worstViolations: string[];
+}
+
+interface TypeSummary {
+  type: string;
+  passRate: number;
+  avgMechanical: number;
+  avgDimension: number;
+  samples: SampleResult[];
+}
+
+export interface EvalResult {
+  pass_rate: number;
+  mean_dimension: number;
+  total_mechanical: number;
+  per_type: Record<string, TypeSummary>;
+  worst_violations: string[];
+  total_samples: number;
+  duration_seconds: number;
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+function loadCoachingPrompt(): string {
+  const promptPath = join(import.meta.dirname ?? ".", "coaching-prompt.md");
+  if (!existsSync(promptPath)) {
+    console.error(`coaching-prompt.md not found at ${promptPath}`);
+    process.exit(1);
+  }
+  return readFileSync(promptPath, "utf-8");
+}
+
+function assemblePrompt(
+  template: string,
+  rules: string,
+  type: string,
+  register: string,
+  prompt: string
+): string {
+  return template
+    .replace("{{RULES}}", rules)
+    .replace("{{TYPE}}", type)
+    .replace("{{REGISTER}}", register)
+    .replace("{{PROMPT}}", prompt);
+}
+
+function generate(fullPrompt: string): string {
+  try {
+    const result = execSync("claude --print --model sonnet", {
+      input: fullPrompt,
+      encoding: "utf-8",
+      timeout: 90_000,
+      maxBuffer: 1024 * 1024,
+      env: cleanEnv(),
+    });
+    return stripMetaCommentary(result.trim());
+  } catch (err) {
+    console.error("Generation failed:", (err as Error).message);
+    return "";
+  }
+}
+
+function collectViolationLabels(compliance: ComplianceResult): string[] {
+  const labels: string[] = [];
+  for (const kw of compliance.mechanical.killWords) {
+    labels.push(`Kill word: ${kw.word} (${kw.severity})`);
+  }
+  for (const sp of compliance.mechanical.slopPatterns) {
+    labels.push(`Slop: ${sp.explanation}`);
+  }
+  for (const v of compliance.mechanical.voiceViolations) {
+    labels.push(`Voice: ${v.type} — ${v.detail.slice(0, 80)}`);
+  }
+  for (const st of compliance.mechanical.structuralTells) {
+    labels.push(`Structural: ${st.pattern}`);
+  }
+  return labels;
+}
+
+// ── Main evaluation ────────────────────────────────────────────────────
+
+function runEval(): EvalResult {
+  const startTime = Date.now();
+  const template = loadCoachingPrompt();
+  const types = Object.keys(ADVERSARIAL_PROMPTS);
+
+  const allSamples: SampleResult[] = [];
+  const perType: Record<string, TypeSummary> = {};
+  const allViolations: string[] = [];
+
+  for (const type of types) {
+    const prompt = ADVERSARIAL_PROMPTS[type];
+    const rules = loadWritingRulesForType(type);
+    const register = REGISTER_MAP[type] ?? "casual";
+    const typeSamples: SampleResult[] = [];
+
+    console.error(`Evaluating ${type}...`);
+
+    for (let i = 0; i < SAMPLES_PER_TYPE; i++) {
+      console.error(`  Sample ${i + 1}/${SAMPLES_PER_TYPE}`);
+      const fullPrompt = assemblePrompt(template, rules, type, register, prompt);
+      const text = generate(fullPrompt);
+
+      if (!text) {
+        typeSamples.push({
+          type,
+          sample: i + 1,
+          mechanicalIssues: 99,
+          dimensionTotal: 0,
+          pass: false,
+          worstViolations: ["Generation failed"],
+        });
+        continue;
+      }
+
+      const compliance = runComplianceCheck(text, type);
+      const mechIssues = compliance.summary.mechanicalIssues;
+      const dimTotal = compliance.dimensions?.total ?? 0;
+      const pass = mechIssues === 0 && dimTotal >= 35;
+      const violations = collectViolationLabels(compliance);
+
+      const sample: SampleResult = {
+        type,
+        sample: i + 1,
+        mechanicalIssues: mechIssues,
+        dimensionTotal: dimTotal,
+        pass,
+        worstViolations: violations,
+      };
+
+      typeSamples.push(sample);
+      allViolations.push(...violations.map((v) => `[${type}] ${v}`));
+    }
+
+    const passCount = typeSamples.filter((s) => s.pass).length;
+    const avgMech = typeSamples.reduce((s, x) => s + x.mechanicalIssues, 0) / typeSamples.length;
+    const avgDim = typeSamples.reduce((s, x) => s + x.dimensionTotal, 0) / typeSamples.length;
+
+    perType[type] = {
+      type,
+      passRate: Math.round((passCount / typeSamples.length) * 1000) / 1000,
+      avgMechanical: Math.round(avgMech * 10) / 10,
+      avgDimension: Math.round(avgDim * 10) / 10,
+      samples: typeSamples,
+    };
+
+    allSamples.push(...typeSamples);
+  }
+
+  const totalPass = allSamples.filter((s) => s.pass).length;
+  const totalMech = allSamples.reduce((s, x) => s + x.mechanicalIssues, 0);
+  const meanDim = allSamples.reduce((s, x) => s + x.dimensionTotal, 0) / allSamples.length;
+
+  // Deduplicate and count violations for worst_violations
+  const violationCounts = new Map<string, number>();
+  for (const v of allViolations) {
+    violationCounts.set(v, (violationCounts.get(v) ?? 0) + 1);
+  }
+  const worstViolations = Array.from(violationCounts.entries())
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 15)
+    .map(([v, count]) => `${v} (×${count})`);
+
+  return {
+    pass_rate: Math.round((totalPass / allSamples.length) * 1000) / 1000,
+    mean_dimension: Math.round(meanDim * 10) / 10,
+    total_mechanical: totalMech,
+    per_type: perType,
+    worst_violations: worstViolations,
+    total_samples: allSamples.length,
+    duration_seconds: Math.round((Date.now() - startTime) / 1000),
+  };
+}
+
+// ── CLI ────────────────────────────────────────────────────────────────
+
+const result = runEval();
+console.log(JSON.stringify(result, null, 2));

--- a/mcp/scripts/autoresearch/ideas.md
+++ b/mcp/scripts/autoresearch/ideas.md
@@ -1,0 +1,4 @@
+# Ideas backlog
+
+Deferred hypotheses for future iterations. One per line.
+

--- a/mcp/scripts/autoresearch/loop.ts
+++ b/mcp/scripts/autoresearch/loop.ts
@@ -1,0 +1,347 @@
+#!/usr/bin/env npx tsx
+
+/**
+ * Autoresearch orchestrator.
+ * Modify coaching-prompt.md → eval → keep/revert → repeat.
+ * Domain-agnostic infrastructure — knows about files, metrics, and git.
+ */
+
+import { readFileSync, writeFileSync, existsSync, appendFileSync } from "fs";
+import { execSync } from "child_process";
+import { join } from "path";
+import { cleanEnv } from "../shared.ts";
+import type { EvalResult } from "./eval.ts";
+
+// ── Config ─────────────────────────────────────────────────────────────
+
+const DIR = import.meta.dirname ?? ".";
+const COACHING_PROMPT_PATH = join(DIR, "coaching-prompt.md");
+const RESULTS_PATH = join(DIR, "results.tsv");
+const IDEAS_PATH = join(DIR, "ideas.md");
+const SESSION_PATH = join(DIR, "session.md");
+const PROGRAM_PATH = join(DIR, "program.md");
+const EVAL_SCRIPT = join(DIR, "eval.ts");
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+function readFile(path: string): string {
+  return existsSync(path) ? readFileSync(path, "utf-8") : "";
+}
+
+interface ResultsState {
+  nextRun: number;
+  best: { passRate: number; meanDimension: number };
+  lastN: string;
+}
+
+function parseResults(n: number = 10): ResultsState {
+  if (!existsSync(RESULTS_PATH)) {
+    return { nextRun: 1, best: { passRate: 0, meanDimension: 0 }, lastN: "(no results yet)" };
+  }
+  const lines = readFileSync(RESULTS_PATH, "utf-8").trim().split("\n");
+  const header = lines[0];
+  const dataLines = lines.slice(1).filter((l) => l.trim());
+
+  // Next run number
+  let nextRun = 1;
+  if (dataLines.length > 0) {
+    const lastRun = parseInt(dataLines[dataLines.length - 1].split("\t")[0], 10);
+    nextRun = (isNaN(lastRun) ? 0 : lastRun) + 1;
+  }
+
+  // Best kept result
+  let best = { passRate: 0, meanDimension: 0 };
+  for (const line of dataLines) {
+    const cols = line.split("\t");
+    if (cols[5] === "true") {
+      const passRate = parseFloat(cols[1]);
+      const meanDim = parseFloat(cols[2]);
+      if (!isNaN(passRate) && passRate >= best.passRate) {
+        if (passRate > best.passRate || (!isNaN(meanDim) && meanDim > best.meanDimension)) {
+          best = { passRate, meanDimension: isNaN(meanDim) ? 0 : meanDim };
+        }
+      }
+    }
+  }
+
+  // Last N rows
+  const tail = dataLines.slice(-n);
+  const lastN = [header, ...tail].join("\n");
+
+  return { nextRun, best, lastN };
+}
+
+function runEval(): EvalResult {
+  console.log("Running evaluation...");
+  const result = execSync(`npx tsx ${EVAL_SCRIPT}`, {
+    encoding: "utf-8",
+    timeout: 600_000, // 10 min max
+    maxBuffer: 10 * 1024 * 1024,
+    env: cleanEnv(),
+    cwd: DIR,
+  });
+
+  // eval.ts logs progress to stderr, JSON to stdout
+  // execSync captures stdout only
+  return JSON.parse(result);
+}
+
+function gitCommit(message: string): void {
+  try {
+    execSync(`git add ${COACHING_PROMPT_PATH} ${RESULTS_PATH} ${SESSION_PATH} ${IDEAS_PATH}`, {
+      cwd: join(DIR, "../../.."),
+      encoding: "utf-8",
+    });
+    const repoRoot = join(DIR, "../../..");
+    execSync("git commit -F -", {
+      input: message,
+      cwd: repoRoot,
+      encoding: "utf-8",
+    });
+  } catch (err) {
+    console.error("Git commit failed:", (err as Error).message);
+  }
+}
+
+function gitRevert(): void {
+  try {
+    execSync(`git checkout -- ${COACHING_PROMPT_PATH}`, {
+      cwd: join(DIR, "../../.."),
+      encoding: "utf-8",
+    });
+  } catch (err) {
+    console.error("Git revert failed:", (err as Error).message);
+  }
+}
+
+function initResultsTsv(): void {
+  if (!existsSync(RESULTS_PATH)) {
+    writeFileSync(
+      RESULTS_PATH,
+      "run\tpass_rate\tmean_dimension\ttotal_mechanical\thypothesis\tkept\tnotes\ttimestamp\n"
+    );
+  }
+}
+
+function appendResult(
+  run: number,
+  evalResult: EvalResult,
+  hypothesis: string,
+  kept: boolean,
+  notes: string
+): void {
+  const row = [
+    run,
+    evalResult.pass_rate,
+    evalResult.mean_dimension,
+    evalResult.total_mechanical,
+    hypothesis.replace(/\t/g, " ").replace(/\n/g, " "),
+    kept,
+    notes.replace(/\t/g, " ").replace(/\n/g, " "),
+    new Date().toISOString(),
+  ].join("\t");
+  appendFileSync(RESULTS_PATH, row + "\n");
+}
+
+function updateSession(run: number, evalResult: EvalResult, hypothesis: string, kept: boolean): void {
+  const entry = `\n### Run ${String(run).padStart(3, "0")} — ${new Date().toISOString().slice(0, 16)}\n- Hypothesis: ${hypothesis}\n- Pass rate: ${evalResult.pass_rate} | Dim: ${evalResult.mean_dimension} | Mech: ${evalResult.total_mechanical}\n- Result: ${kept ? "KEPT" : "REVERTED"}\n`;
+
+  const current = readFile(SESSION_PATH);
+  const historyMarker = "## History";
+  if (current.includes(historyMarker)) {
+    const [before, after] = current.split(historyMarker);
+    writeFileSync(SESSION_PATH, `${before}${historyMarker}\n${entry}${after ? after.replace(/^\n*/, "\n") : "\n"}`);
+  } else {
+    appendFileSync(SESSION_PATH, `\n${historyMarker}\n${entry}`);
+  }
+}
+
+function appendIdeas(newIdeas: string): void {
+  if (!newIdeas.trim()) return;
+  appendFileSync(IDEAS_PATH, "\n" + newIdeas.trim() + "\n");
+}
+
+// ── Agent call ─────────────────────────────────────────────────────────
+
+function callAgent(
+  currentPrompt: string,
+  lastResults: string,
+  worstViolations: string[],
+  ideas: string
+): { prompt: string; hypothesis: string; newIdeas: string } {
+  const program = readFile(PROGRAM_PATH);
+
+  const agentPrompt = `${program}
+
+---
+
+## Current state
+
+### Current coaching prompt
+\`\`\`
+${currentPrompt}
+\`\`\`
+
+### Last 10 results
+\`\`\`
+${lastResults}
+\`\`\`
+
+### Worst violations from last eval
+${worstViolations.length > 0 ? worstViolations.map((v) => `- ${v}`).join("\n") : "(none — this is the baseline or previous run had no violations)"}
+
+### Ideas backlog
+${ideas || "(empty)"}
+
+---
+
+Based on the above, propose your next modification to coaching-prompt.md. Remember: one hypothesis, output between <prompt> tags, hypothesis in <hypothesis> tags, optional <ideas> for deferred hypotheses.`;
+
+  const result = execSync("claude --print --model sonnet", {
+    input: agentPrompt,
+    encoding: "utf-8",
+    timeout: 120_000,
+    maxBuffer: 2 * 1024 * 1024,
+    env: cleanEnv(),
+  });
+
+  // Parse response
+  const hypothesisMatch = result.match(/<hypothesis>([\s\S]*?)<\/hypothesis>/);
+  const promptMatch = result.match(/<prompt>([\s\S]*?)<\/prompt>/);
+  const ideasMatch = result.match(/<ideas>([\s\S]*?)<\/ideas>/);
+
+  if (!promptMatch) {
+    throw new Error("Agent did not return a <prompt> block");
+  }
+
+  const newPrompt = promptMatch[1].trim();
+
+  // Validate placeholders
+  const required = ["{{RULES}}", "{{TYPE}}", "{{REGISTER}}", "{{PROMPT}}"];
+  for (const placeholder of required) {
+    if (!newPrompt.includes(placeholder)) {
+      throw new Error(`Agent prompt missing required placeholder: ${placeholder}`);
+    }
+  }
+
+  return {
+    prompt: newPrompt,
+    hypothesis: hypothesisMatch ? hypothesisMatch[1].trim() : "no hypothesis provided",
+    newIdeas: ideasMatch ? ideasMatch[1].trim() : "",
+  };
+}
+
+// ── Main loop ──────────────────────────────────────────────────────────
+
+function main(): void {
+  const args = process.argv.slice(2);
+  const maxIterations = args.includes("--max")
+    ? parseInt(args[args.indexOf("--max") + 1], 10)
+    : Infinity;
+  const baselineOnly = args.includes("--baseline");
+
+  initResultsTsv();
+
+  // Check if we need a baseline
+  const { nextRun: runNum } = parseResults();
+
+  if (runNum === 1 || baselineOnly) {
+    console.log("Running baseline evaluation...");
+    const evalResult = runEval();
+    appendResult(1, evalResult, "baseline", true, "initial baseline");
+    updateSession(1, evalResult, "baseline", true);
+    gitCommit("autoresearch: baseline run 001");
+    console.log(`Baseline: pass_rate=${evalResult.pass_rate}, dim=${evalResult.mean_dimension}, mech=${evalResult.total_mechanical}`);
+
+    if (baselineOnly) {
+      console.log("Baseline recorded. Exiting.");
+      return;
+    }
+  }
+
+  // Main loop
+  let iteration = 0;
+  while (iteration < maxIterations) {
+    const state = parseResults();
+    const currentRun = state.nextRun;
+    iteration++;
+
+    console.log(`\n${"=".repeat(60)}`);
+    console.log(`Run ${String(currentRun).padStart(3, "0")} (iteration ${iteration})`);
+    console.log("=".repeat(60));
+
+    const currentPrompt = readFile(COACHING_PROMPT_PATH);
+    const best = state.best;
+    const ideas = readFile(IDEAS_PATH);
+
+    // Get last eval's worst violations from results
+    let lastWorstViolations: string[] = [];
+    try {
+      // Re-run would be expensive; parse from session if available
+      const session = readFile(SESSION_PATH);
+      // Simple approach: we'll pass empty if no previous violations cached
+      // The agent will work with results.tsv data instead
+      lastWorstViolations = [];
+    } catch {
+      // fine
+    }
+
+    // Step 1: Ask agent for modification
+    console.log("Asking agent for next modification...");
+    let agentResult;
+    try {
+      agentResult = callAgent(currentPrompt, state.lastN, lastWorstViolations, ideas);
+    } catch (err) {
+      console.error("Agent call failed:", (err as Error).message);
+      console.log("Waiting 30s before retry...");
+      execSync("sleep 30");
+      continue;
+    }
+
+    console.log(`Hypothesis: ${agentResult.hypothesis}`);
+
+    // Step 2: Write new coaching prompt
+    const backupPrompt = currentPrompt;
+    writeFileSync(COACHING_PROMPT_PATH, agentResult.prompt);
+
+    // Step 3: Append any new ideas
+    if (agentResult.newIdeas) {
+      appendIdeas(agentResult.newIdeas);
+    }
+
+    // Step 4: Evaluate
+    let evalResult: EvalResult;
+    try {
+      evalResult = runEval();
+    } catch (err) {
+      console.error("Eval failed:", (err as Error).message);
+      writeFileSync(COACHING_PROMPT_PATH, backupPrompt);
+      appendResult(currentRun, { pass_rate: 0, mean_dimension: 0, total_mechanical: 99, worst_violations: [], total_samples: 0, duration_seconds: 0 }, agentResult.hypothesis, false, "eval failed");
+      updateSession(currentRun, { pass_rate: 0, mean_dimension: 0, total_mechanical: 99, worst_violations: [], total_samples: 0, duration_seconds: 0 }, agentResult.hypothesis, false);
+      continue;
+    }
+
+    console.log(`Result: pass_rate=${evalResult.pass_rate}, dim=${evalResult.mean_dimension}, mech=${evalResult.total_mechanical}`);
+
+    // Step 5: Keep or revert
+    const improved = evalResult.pass_rate > best.passRate;
+    const equalButNotWorse = evalResult.pass_rate === best.passRate && evalResult.mean_dimension >= (best.meanDimension - 2);
+    const kept = improved || (equalButNotWorse && evalResult.pass_rate > 0);
+
+    if (kept) {
+      console.log(`KEPT — pass_rate improved or held (${best.passRate} → ${evalResult.pass_rate})`);
+      appendResult(currentRun, evalResult, agentResult.hypothesis, true, "");
+      updateSession(currentRun, evalResult, agentResult.hypothesis, true);
+      gitCommit(`autoresearch: run ${String(currentRun).padStart(3, "0")} — ${agentResult.hypothesis.slice(0, 60)}`);
+    } else {
+      console.log(`REVERTED — pass_rate regressed (${best.passRate} → ${evalResult.pass_rate})`);
+      writeFileSync(COACHING_PROMPT_PATH, backupPrompt);
+      appendResult(currentRun, evalResult, agentResult.hypothesis, false, "reverted");
+      updateSession(currentRun, evalResult, agentResult.hypothesis, false);
+    }
+  }
+
+  console.log("\nAutoresearch loop complete.");
+}
+
+main();

--- a/mcp/scripts/autoresearch/program.md
+++ b/mcp/scripts/autoresearch/program.md
@@ -1,0 +1,57 @@
+# Autoresearch: coaching prompt optimization
+
+You are an autonomous agent optimizing the coaching prompt that wraps writing rules when asking an AI to write prose. Your goal is to maximize the **pass rate** — the percentage of generated samples that have zero mechanical issues AND a dimension score ≥ 35 out of 50.
+
+## What you can modify
+
+**Only `coaching-prompt.md`** — the prompt template with placeholders `{{RULES}}`, `{{TYPE}}`, `{{REGISTER}}`, `{{PROMPT}}`.
+
+## What is frozen (do not attempt to modify)
+
+- The 9 adversarial prompts (hardcoded test cases)
+- The compliance scoring logic (mechanical checks + dimension scoring)
+- The writing rules in SQLite (user-authored ground truth)
+- The evaluation harness (`eval.ts`)
+
+## Primary metric
+
+**Pass rate**: % of 27 samples where `mechanicalIssues === 0 AND dimensions.total >= 35`
+
+Secondary: mean dimension score. Tiebreaker: total mechanical issues (lower is better).
+
+## Strategy
+
+### Levers available to you
+
+1. **Framing** — how you position the rules (as constraints? as a voice profile? as an editor's notes?)
+2. **Emphasis** — which rule categories you call out explicitly vs leave implicit
+3. **Negative examples** — showing what NOT to do (kill words, slop patterns)
+4. **Structure** — ordering of instructions, XML tags, section breaks
+5. **Tone of instruction** — imperative ("Never use...") vs descriptive ("This voice avoids...")
+6. **Meta-instructions** — telling the model to self-edit, re-read rules, etc.
+
+### Common failure modes
+
+- **Kill words** — the model uses banned words/phrases despite rules listing them. Direct prohibition may work better than indirect description.
+- **Structural tells** — negative parallelism ("it's not X — it's Y"), AI presentation verbs ("underscoring", "showcasing"). These need explicit callouts.
+- **Register confusion** — casual rules bleeding into professional writing or vice versa.
+- **Over-explanation** — the model explains itself instead of just writing.
+- **Meta-commentary** — the model adds word counts, critiques, or framing around the prose.
+
+### Principles
+
+- **One hypothesis per experiment.** Change one thing, measure, keep or revert.
+- **Simplicity wins.** A small improvement that adds complexity is not worth it. Prefer shorter prompts that work over longer prompts that work slightly better.
+- **Read the worst violations.** The eval output includes the worst violations from the last run. These are your strongest signal for what to fix next.
+- **Don't overfit.** The 27 samples are a small test set. Prefer general improvements over prompt-hacking specific test cases.
+- **Never stop.** After each experiment, formulate the next hypothesis and continue.
+
+## Output format
+
+When asked to modify the coaching prompt, respond with:
+
+1. `<hypothesis>` — what you're testing and why
+2. `<prompt>` — the complete new coaching-prompt.md content (include all placeholders)
+3. `<ideas>` (optional) — deferred hypotheses to try later, one per line
+
+The prompt MUST contain all four placeholders: `{{RULES}}`, `{{TYPE}}`, `{{REGISTER}}`, `{{PROMPT}}`.

--- a/mcp/scripts/autoresearch/session.md
+++ b/mcp/scripts/autoresearch/session.md
@@ -1,0 +1,11 @@
+# Autoresearch session
+
+Auto-updated by loop.ts. Enables resumability across agent sessions.
+
+## Status
+
+Not yet started. Run `npx tsx mcp/scripts/autoresearch/loop.ts` to begin.
+
+## History
+
+(populated by loop.ts)

--- a/mcp/scripts/shared.ts
+++ b/mcp/scripts/shared.ts
@@ -1,0 +1,133 @@
+/**
+ * Shared utilities for adversarial testing and autoresearch.
+ * Extracted from adversarial-test.ts to avoid duplication.
+ */
+
+import { readFileSync, existsSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
+
+// ── Adversarial prompts ────────────────────────────────────────────────
+
+export const ADVERSARIAL_PROMPTS: Record<string, string> = {
+  general:
+    "Write a 200-word blog intro about why product managers should learn to code",
+  email:
+    "Draft a follow-up email after a job interview at a company you're excited about",
+  "cover-letter":
+    "Write an opening paragraph for a PM role at Stripe",
+  outreach:
+    "Draft a cold LinkedIn message to a VP of Product at a Series B startup",
+  prd:
+    "Write the problem statement section for a feature that adds dark mode",
+  blog:
+    "Write a paragraph arguing that most product roadmaps are theater",
+  resume:
+    "Write a bullet point for leading a product redesign that increased retention 15%",
+  slack:
+    "Write a message asking your team to review a doc before Friday",
+  pitch:
+    "Write the opening of a pitch deck for a reading annotation tool",
+};
+
+export const SAMPLES_PER_TYPE = 3;
+
+export const REGISTER_MAP: Record<string, string> = {
+  general: "casual",
+  email: "casual",
+  slack: "casual",
+  outreach: "casual",
+  pitch: "professional",
+  prd: "professional",
+  "cover-letter": "professional",
+  resume: "professional",
+  blog: "professional",
+};
+
+// ── Types ──────────────────────────────────────────────────────────────
+
+export interface WritingRuleRow {
+  writing_type: string;
+  category: string;
+  rule_text: string;
+  severity: string;
+  example_before: string | null;
+  example_after: string | null;
+  register: string | null;
+}
+
+// ── Shared utilities ───────────────────────────────────────────────────
+
+function loadWritingRules(): string {
+  const rulesPath = join(homedir(), ".margin/writing-rules.md");
+  if (!existsSync(rulesPath)) {
+    console.error(`Writing rules not found at ${rulesPath}`);
+    process.exit(1);
+  }
+  return readFileSync(rulesPath, "utf-8");
+}
+
+export function loadWritingRulesForType(type: string): string {
+  try {
+    const Database = require("better-sqlite3");
+    const dbPath = join(homedir(), ".margin/margin.db");
+    if (!existsSync(dbPath)) return loadWritingRules();
+
+    const db = new Database(dbPath, { readonly: true });
+    const register = REGISTER_MAP[type] ?? "casual";
+
+    const rows = db
+      .prepare(
+        `SELECT writing_type, category, rule_text, severity, example_before, example_after, register
+         FROM writing_rules
+         WHERE (writing_type = ? OR writing_type = 'general' OR register = ?)
+         ORDER BY signal_count DESC, created_at DESC`
+      )
+      .all(type, register) as WritingRuleRow[];
+    db.close();
+
+    if (rows.length === 0) return loadWritingRules();
+
+    const grouped = new Map<string, Map<string, WritingRuleRow[]>>();
+    for (const row of rows) {
+      if (!grouped.has(row.writing_type)) grouped.set(row.writing_type, new Map());
+      const categories = grouped.get(row.writing_type)!;
+      if (!categories.has(row.category)) categories.set(row.category, []);
+      categories.get(row.category)!.push(row);
+    }
+
+    const lines: string[] = [`# Writing Rules (filtered for: ${type}, register: ${register})`];
+
+    for (const [writingType, categories] of grouped) {
+      lines.push("", `## ${writingType.charAt(0).toUpperCase() + writingType.slice(1)}`);
+      for (const [category, rules] of categories) {
+        lines.push(`### ${category}`);
+        for (const rule of rules) {
+          lines.push(`- [${rule.severity}] ${rule.rule_text}`);
+          if (rule.example_before) lines.push(`  - Before: "${rule.example_before}"`);
+          if (rule.example_after) lines.push(`  - After: "${rule.example_after}"`);
+        }
+      }
+    }
+
+    return lines.join("\n");
+  } catch {
+    return loadWritingRules();
+  }
+}
+
+export function cleanEnv(): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  delete env.CLAUDECODE;
+  return env;
+}
+
+export function stripMetaCommentary(text: string): string {
+  const fenceMatch = text.match(/---\n([\s\S]+?)\n---/);
+  if (fenceMatch) return fenceMatch[1].trim();
+
+  let cleaned = text.replace(/^(?:Here['']s|Writing rules|I['']ll)[^\n]*\n+/i, "");
+  cleaned = cleaned.replace(/\n+(?:\*\*Critique|~\d+\s*words|^\(.+\)$|\*\(.+\)\*).*/ms, "");
+
+  return cleaned.trim();
+}

--- a/src/components/layout/__tests__/Sidebar.test.tsx
+++ b/src/components/layout/__tests__/Sidebar.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, act } from "@testing-library/react";
 import { Sidebar } from "../Sidebar";
 import type { Document } from "@/types/document";
 import type { Tab } from "@/types/tab";
@@ -73,13 +73,24 @@ describe("Sidebar", () => {
   });
 
   describe("search input container", () => {
-    it("has transition-colors and duration-150 classes", () => {
-      render(<Sidebar {...defaultProps} />);
+    it("has transition-colors and duration-150 classes", async () => {
+      // useAnimatedPresence schedules timers on mount. In the full suite, Reader.test.tsx
+      // (TipTap) leaves pending rAF callbacks that cause React 19's act() to poll indefinitely.
+      // Fix: fake timers + vi.runAllTimers() flushes all pending work before querying.
+      vi.useFakeTimers();
+      try {
+        await act(async () => {
+          render(<Sidebar {...defaultProps} />);
+          vi.runAllTimers();
+        });
 
-      const searchInput = screen.getByPlaceholderText("Search documents...");
-      const container = searchInput.closest("div.flex.items-center");
-      expect(container?.className).toContain("transition-colors");
-      expect(container?.className).toContain("duration-150");
+        const searchInput = screen.getByPlaceholderText("Search documents...");
+        const container = searchInput.closest("div.flex.items-center");
+        expect(container?.className).toContain("transition-colors");
+        expect(container?.className).toContain("duration-150");
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,22 +6,26 @@ import path from "path";
 // runs). With fileParallelism: false (serial execution), this backfires: tiny files end up
 // last, when system memory is most depleted after 37 workers, causing worker spawn timeouts.
 //
-// Fix: run the smallest hook tests first, before the heavy jsdom/TipTap component tests
-// have exhausted system resources. The rest still runs in vitest's default large-first order.
+// Fix: pin hook/lib tests first (smallest, most resource-constrained), then run all remaining
+// files in smallest-first order so no small file ever lands at the tail of a depleted queue.
 class HookFirstSequencer extends BaseSequencer {
   async sort(files: Parameters<BaseSequencer["sort"]>[0]) {
-    const sorted = await super.sort(files);
-    // Pin pure hook tests (≤6 KB) to the front — these are the files that otherwise land
-    // last due to their small size and fail with "Timeout waiting for worker to respond".
-    const small = sorted.filter((f) => {
+    const sorted = await super.sort(files); // largest-first (vitest default)
+    // Pin pure hook/lib tests to the front — these are the smallest files and must not land
+    // last after heavy jsdom/TipTap workers have exhausted system resources.
+    const pinned = sorted.filter((f) => {
       const rel = f.moduleId.replace(/\\/g, "/");
       return rel.includes("/hooks/__tests__/") || rel.includes("/lib/__tests__/");
     });
-    const rest = sorted.filter((f) => {
-      const rel = f.moduleId.replace(/\\/g, "/");
-      return !rel.includes("/hooks/__tests__/") && !rel.includes("/lib/__tests__/");
-    });
-    return [...small, ...rest];
+    // Reverse the remaining files: vitest's large-first order becomes small-first, so no
+    // small component test can end up at the very end of the queue when memory is depleted.
+    const rest = sorted
+      .filter((f) => {
+        const rel = f.moduleId.replace(/\\/g, "/");
+        return !rel.includes("/hooks/__tests__/") && !rel.includes("/lib/__tests__/");
+      })
+      .reverse();
+    return [...pinned, ...rest];
   }
 }
 

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,6 +1,6 @@
 import "@testing-library/jest-dom/vitest";
 import { cleanup } from "@testing-library/react";
-import { afterEach, vi } from "vitest";
+import { beforeEach, afterEach, vi } from "vitest";
 
 // Node.js 25 introduced a native localStorage stub that lacks the full Storage API.
 // Redefine it with a proper in-memory implementation so tests can call localStorage.clear() etc.
@@ -27,6 +27,14 @@ if (typeof globalThis.ResizeObserver === "undefined") {
     disconnect() {}
   } as unknown as typeof globalThis.ResizeObserver;
 }
+
+beforeEach(() => {
+  // Defensive guard: restore real timers at the START of each test in case a
+  // previous test's cleanup failed (e.g., it timed out before afterEach ran).
+  // Without this, a hung test leaves fake timers on globalThis, which blocks
+  // Vitest's own setTimeout-based 30s timeout — causing 900s+ worker hangs.
+  vi.useRealTimers();
+});
 
 afterEach(() => {
   // Restore real timers after every test so fake timers from one file


### PR DESCRIPTION
## Summary

- `ReadingSection.test.tsx` and `ExportAnnotationsPopover.test.tsx` were timing out on worker spawn with "Timeout waiting for worker to respond"
- Root cause: the `HookFirstSequencer` left non-pinned files in vitest's default largest-first order, so tiny component tests (44–100 lines) settled at positions ~36–37 of 38 — exactly when memory is most depleted
- Fix: reverse the `rest` group after extracting pinned hook/lib files → execution order is now `[hooks/lib] → [small component tests] → [large tests]`

## Test plan

- [x] `pnpm test` — 38 files, 281 tests, 0 unhandled errors (was: 2 worker timeout errors)
- [x] Typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)