### PR TITLE
test(style-memory): fix RulesTab update test userEvent deadlock

### DIFF
--- a/src/components/style-memory/__tests__/RulesTab.test.tsx
+++ b/src/components/style-memory/__tests__/RulesTab.test.tsx
@@ -72,18 +72,17 @@ describe("RulesTab — SeverityBadge", () => {
   });
 
   it("auto-exports profile artifacts after rule update", async () => {
-    const user = userEvent.setup();
     render(<RulesTab onStatsChange={vi.fn()} />);
 
     await screen.findByText("Test rule");
 
-    await user.click(screen.getByRole("button", { name: "Edit" }));
+    // Use fireEvent.click instead of user.click to avoid userEvent pointer-event
+    // deadlock when stale rAF callbacks from preceding test files are still pending
+    // in the jsdom queue (matches IntegrationsSection fix pattern).
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
     const input = screen.getByDisplayValue("Test rule");
-    // Use fireEvent.change instead of user.clear()+user.type() to avoid userEvent
-    // keyboard-event deadlock when stale rAF callbacks from preceding test files are
-    // still pending in the jsdom queue (matches IntegrationsSection fix pattern).
     fireEvent.change(input, { target: { value: "Updated rule text" } });
-    await user.click(screen.getByRole("button", { name: "Save" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => {
       expect(updateWritingRule).toHaveBeenCalled();

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,8 +9,10 @@ import path from "path";
 // is 60s), so late-running workers fail intermittently.
 //
 // Fix: run hook, lib, and lightweight component tests first, before heavy TipTap editor tests
-// exhaust system resources. Reader.test runs first of all (unshift) because it has the heaviest
-// TipTap editor setup and times out if the system is resource-depleted after 30+ other files.
+// exhaust system resources. Reader.test and DiffBanner.test run first of all (unshift) because
+// they time out if system resources are depleted after 30+ other files. Reader.test has the
+// heaviest TipTap editor setup; DiffBanner.test is lightweight but its worker startup times out
+// when it lands late in the 40-file run.
 // Lightweight tests (hooks, lib, settings/*, style-memory/*, layout/Sidebar, DiffNavChip,
 // FloatingToolbar, search) run in the "small" bucket. Heavy editor tests (HighlightThread,
 // ExportAnnotationsPopover, TabBar, etc.) run in "rest".
@@ -27,7 +29,10 @@ class HookFirstSequencer extends BaseSequencer {
       } else if (
         // Reader.test renders the heaviest TipTap editor (all extensions). Run it
         // first so it gets a fresh worker before system resources are depleted.
-        rel.includes("Reader.test")
+        // DiffBanner.test is lightweight but its worker times out when it lands
+        // late in a 40-file serial run — unshift it here too.
+        rel.includes("Reader.test") ||
+        rel.includes("DiffBanner.test")
       ) {
         small.unshift(f);
       } else if (
@@ -35,7 +40,6 @@ class HookFirstSequencer extends BaseSequencer {
         rel.includes("/lib/__tests__/") ||
         rel.includes("/settings/__tests__/") ||
         rel.includes("DiffNavChip.test") ||
-        rel.includes("DiffBanner.test") ||
         rel.includes("FloatingToolbar.test") ||
         rel.includes("Sidebar.test") ||
         rel.includes("StyleMemorySection.test") ||


### PR DESCRIPTION
## Summary
- The `auto-exports profile artifacts after rule update` test was hanging ~16 minutes before timing out
- Root cause: `user.click()` from userEvent deadlocks when stale `requestAnimationFrame` callbacks from preceding test files are pending in the jsdom queue
- Fix: replaced `user.click(Edit)` and `user.click(Save)` with `fireEvent.click` — same pattern already applied to the input (`fireEvent.change`) and to IntegrationsSection

**Addendum (heartbeat run 2026-03-22):** `DiffBanner.test.tsx` worker timed out in full 40-file serial run (~20min). Root cause: DiffBanner was in `small.push` (back of the small bucket) so it ran after ~28 other files; by that point system resources were depleted and the Vitest 60s worker-start timeout hit. Fix: promoted DiffBanner to `small.unshift` alongside Reader.test so it runs in the first 2–3 slots.

## Test plan
- [x] `pnpm test src/components/editor/__tests__/DiffBanner.test.tsx` — 5 tests pass in 6s
- [x] `pnpm test src/components/style-memory/__tests__/RulesTab.test.tsx` — all 3 pass in ~2s
- [x] `pnpm typecheck` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)