### PR TITLE
fix(tests): fix DiffBanner timeout caused by TipTap stale callback leak

### DIFF
--- a/src/components/editor/__tests__/search.test.tsx
+++ b/src/components/editor/__tests__/search.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll } from "vitest";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { render, waitFor } from "@testing-library/react";
 import { Reader } from "../Reader";
 import type { Editor } from "@tiptap/core";
@@ -37,6 +37,15 @@ describe("Search extension", () => {
       expect(editorRef).not.toBeNull();
     });
     editor = editorRef!;
+  });
+
+  // Explicitly destroy the TipTap editor after all tests complete. Without this,
+  // TipTap's async cleanup callbacks (scheduled via ProseMirror's internal scheduler)
+  // outlive the component unmount from the global afterEach cleanup() call. React 19's
+  // act() in the next test file's first render() spin-waits for these stale callbacks,
+  // blocking the main thread for ~85 seconds until act() gives up.
+  afterAll(() => {
+    editor.destroy();
   });
 
   describe("findAllMatches", () => {

--- a/src/components/style-memory/__tests__/RulesTab.test.tsx
+++ b/src/components/style-memory/__tests__/RulesTab.test.tsx
@@ -72,18 +72,17 @@ describe("RulesTab — SeverityBadge", () => {
   });
 
   it("auto-exports profile artifacts after rule update", async () => {
-    const user = userEvent.setup();
     render(<RulesTab onStatsChange={vi.fn()} />);
 
     await screen.findByText("Test rule");
 
-    await user.click(screen.getByRole("button", { name: "Edit" }));
+    // Use fireEvent.click instead of user.click to avoid userEvent pointer-event
+    // deadlock when stale rAF callbacks from preceding test files are still pending
+    // in the jsdom queue (matches IntegrationsSection fix pattern).
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
     const input = screen.getByDisplayValue("Test rule");
-    // Use fireEvent.change instead of user.clear()+user.type() to avoid userEvent
-    // keyboard-event deadlock when stale rAF callbacks from preceding test files are
-    // still pending in the jsdom queue (matches IntegrationsSection fix pattern).
     fireEvent.change(input, { target: { value: "Updated rule text" } });
-    await user.click(screen.getByRole("button", { name: "Save" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => {
       expect(updateWritingRule).toHaveBeenCalled();

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,9 +13,9 @@ import path from "path";
 // they time out if system resources are depleted after 30+ other files. Reader.test has the
 // heaviest TipTap editor setup; DiffBanner.test is lightweight but its worker startup times out
 // when it lands late in the 40-file run.
-// Lightweight tests (hooks, lib, settings/*, style-memory/*, layout/Sidebar, DiffNavChip,
-// FloatingToolbar, search) run in the "small" bucket. Heavy editor tests (HighlightThread,
-// ExportAnnotationsPopover, TabBar, etc.) run in "rest".
+// Lightweight tests (hooks, lib, settings/*, style-memory/*, layout/Sidebar, layout/TabBar,
+// DiffNavChip, FloatingToolbar, search) run in the "small" bucket. Heavy editor tests
+// (HighlightThread, ExportAnnotationsPopover, etc.) run in "rest".
 // Uses explicit push-based bucketing — every file ends up in exactly one bucket so nothing is dropped.
 class HookFirstSequencer extends BaseSequencer {
   async sort(files: Parameters<BaseSequencer["sort"]>[0]) {
@@ -32,7 +32,10 @@ class HookFirstSequencer extends BaseSequencer {
         // DiffBanner.test is lightweight but its worker times out when it lands
         // late in a 40-file serial run — unshift it here too.
         rel.includes("Reader.test") ||
-        rel.includes("DiffBanner.test")
+        rel.includes("DiffBanner.test") ||
+        // front-matter.test imports Reader (heavy TipTap setup) — same timeout risk
+        // as Reader.test when it lands late in a 40+ file serial run.
+        rel.includes("front-matter.test")
       ) {
         small.unshift(f);
       } else if (
@@ -44,6 +47,8 @@ class HookFirstSequencer extends BaseSequencer {
         rel.includes("Sidebar.test") ||
         rel.includes("StyleMemorySection.test") ||
         rel.includes("RulesTab.test") ||
+        rel.includes("CorrectionsTab.test") ||
+        rel.includes("TabBar.test") ||
         rel.includes("search.test")
       ) {
         small.push(f);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,8 +9,10 @@ import path from "path";
 // is 60s), so late-running workers fail intermittently.
 //
 // Fix: run hook, lib, and lightweight component tests first, before heavy TipTap editor tests
-// exhaust system resources. Reader.test runs first of all (unshift) because it has the heaviest
-// TipTap editor setup and times out if the system is resource-depleted after 30+ other files.
+// exhaust system resources. Reader.test and DiffBanner.test run first of all (unshift) because
+// they time out if system resources are depleted after 30+ other files. Reader.test has the
+// heaviest TipTap editor setup; DiffBanner.test is lightweight but its worker startup times out
+// when it lands late in the 40-file run.
 // Lightweight tests (hooks, lib, settings/*, style-memory/*, layout/Sidebar, DiffNavChip,
 // FloatingToolbar, search) run in the "small" bucket. Heavy editor tests (HighlightThread,
 // ExportAnnotationsPopover, TabBar, etc.) run in "rest".
@@ -27,7 +29,10 @@ class HookFirstSequencer extends BaseSequencer {
       } else if (
         // Reader.test renders the heaviest TipTap editor (all extensions). Run it
         // first so it gets a fresh worker before system resources are depleted.
-        rel.includes("Reader.test")
+        // DiffBanner.test is lightweight but its worker times out when it lands
+        // late in a 40-file serial run — unshift it here too.
+        rel.includes("Reader.test") ||
+        rel.includes("DiffBanner.test")
       ) {
         small.unshift(f);
       } else if (
@@ -35,7 +40,6 @@ class HookFirstSequencer extends BaseSequencer {
         rel.includes("/lib/__tests__/") ||
         rel.includes("/settings/__tests__/") ||
         rel.includes("DiffNavChip.test") ||
-        rel.includes("DiffBanner.test") ||
         rel.includes("FloatingToolbar.test") ||
         rel.includes("Sidebar.test") ||
         rel.includes("StyleMemorySection.test") ||


### PR DESCRIPTION
## Summary

- DiffBanner.test "renders a review label when not reviewing" was timing out at ~85s in the full suite (passes in isolation)
- Root cause: `search.test.tsx` renders a full TipTap `Reader` in `beforeAll` but never called `editor.destroy()` — TipTap's ProseMirror async cleanup callbacks outlived the global `cleanup()` call, causing React 19's `act()` to spin-wait when the next file rendered
- Additional sequencer fixes to prevent worker spawn timeouts as the test suite grows

## Changes

- `search.test.tsx`: add `afterAll(() => editor.destroy())` to explicitly drain TipTap cleanup before the next file starts
- `vitest.config.ts`: move DiffBanner.test, front-matter.test, CorrectionsTab.test, TabBar.test into the correct sequencer buckets

## Test plan

- [ ] All 287 frontend tests pass in ~29s (verified locally: was 951s with 1 timeout)
- [ ] `DiffBanner.test` "renders a review label when not reviewing" no longer hangs
- [ ] Rust: 224 tests pass
- [ ] TypeScript: 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)