### PR TITLE
feat: make feedback learning continuous

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -7,57 +7,42 @@ Replace the active task section when new substantial work starts.
 
 ### Task
 
-Execute `plans/repair-spec-2026-07.md` on branch `fix/loop-repair-2026-07`.
+Make Margin's two product pillars explicit and ship the first missing behavior for each pillar on branch `feat/two-pillar-product`.
 
 ### Outcome
 
-The July repair P0s are implemented with failing-test-first evidence, verified locally, and reported in `plans/repair-report-2026-07.md`. Commit/push is blocked in this sandbox because `.git` is read-only.
+Margin treats the Markdown reading and writing experience as a core product, and feedback saved in the margin becomes local learning data without requiring an export step.
 
 ### Constraints
 
-- Work only on `fix/loop-repair-2026-07`.
-- Implement P0 fixes first; P1 only after all P0s are verified.
-- Write a failing test before each fix.
-- Stop and write `plans/repair-bounceback.md` if a spec bounce-back trigger or discard condition is hit.
-- Do not touch anything under `mcp/scripts/`.
-- Run all four required quality gates before committing:
-  - `cargo check --manifest-path src-tauri/Cargo.toml`
-  - `cargo test --manifest-path src-tauri/Cargo.toml`
-  - `pnpm tsc --noEmit`
-  - `pnpm test`
-- Stage only files changed for this repair.
+- Keep Markdown files portable and preserve round-trip behavior.
+- Keep SQLite authoritative for feedback and rules.
+- Keep automatic learning inspectable and reversible; synthesis remains reviewable.
+- Preserve correction-event history after synthesis while updating the current unsynthesized signal in place.
+- Write failing tests before each behavior change.
+- Run `scripts/verify full`, stage only this task's files, commit, and push.
 
 ### Steps
 
-1. P0-1: add note intent taxonomy, schema migration, export filtering, prompt sidecar, summary counts, and tests.
-2. P0-2: fix note-button selection capture, reject whitespace highlights, reject empty correction text, surface failures, and tests.
-3. P0-3: resolve `margin` CLI robustly for GUI PATH, surface auto-export failures, log failures, and tests.
-4. Run the required quality gates.
-5. Write the repair report with exact outputs.
-6. Commit and push the branch.
+1. Add failing tests for first-class formatting controls in the selection toolbar.
+2. Add failing Rust tests for continuous feedback capture and unsynthesized-signal updates.
+3. Implement both behaviors and wire visible error handling into the app.
+4. Rewrite the product contract, architecture, invariants, and evals around the two pillars.
+5. Run the full verification gate, commit, and push.
 
 ### Decisions
 
-- The three note intents are fixed by spec: `correction`, `note`, and `prompt`.
-- Only `correction` notes become correction rows.
-- `prompt` notes are skipped from corrections and written to a prompt sidecar.
-- Silent pipeline failures should become visible app errors and log entries.
-
-### Surprises
-
-- The working tree started with many untracked files, including `mcp/scripts/`; those are treated as pre-existing and must not be staged.
-- Several open branches touch high-collision files. Keep high-collision edits narrow and bounce if an actual hunk conflict appears.
+- The two pillars are peers. Reading and writing quality is not a disposable input surface for the learning system.
+- A saved correction note becomes a correction row immediately. Later edits update the current unsynthesized row; feedback after synthesis creates a new event.
+- Formatting controls share the selection toolbar with annotation controls so writing and feedback stay in one flow.
 
 ### Verification
 
-- `cargo check --manifest-path src-tauri/Cargo.toml` passed.
-- `cargo test --manifest-path src-tauri/Cargo.toml` passed: 228 Rust tests, 0 failed; doc-tests passed.
-- `pnpm tsc --noEmit` passed with no output.
-- `pnpm test` passed: 42 files, 289 tests.
-- Targeted failing-test-first evidence and passing reruns are recorded in `plans/repair-report-2026-07.md`.
+- Failing-test-first evidence recorded for the formatting toolbar, continuous feedback capture, default learning preference, and export de-duplication.
+- `scripts/verify full` passed with the matching Node 22 runtime: 294 frontend tests, production build, 184 MCP tests, MCP TypeScript, gap audit, cargo check, and 231 Rust tests.
+- `scripts/verify standard` passed without an environment override after replacing the stale versioned Node path with Homebrew's stable `node@22` path.
+- An additional `cargo clippy -- -D warnings` check remains blocked by 11 existing warnings in unchanged code. None point to the new feedback module or toolbar.
 
 ### Handoff
 
-P0 repair completed and verified. P1 was not attempted in this pass to keep the medium-risk data-path diff reviewable after all four P0 gates passed.
-
-Commit/push blocker: `git add ...` failed with `fatal: Unable to create '/Users/samzoloth/Projects/margin/.git/index.lock': Operation not permitted`. No files are staged.
+The two-pillar product contract, formatting controls, local learning default, continuous feedback capture, export de-duplication, and stable verification path are ready on `feat/two-pillar-product`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 ## System Purpose
 
-Margin is a local-first writing quality system. It captures editorial judgment from reading, stores that signal in SQLite, synthesizes it into writing rules, and exports enforceable artifacts that keep Claude from repeating patterns the user has flagged.
+Margin is a local-first Markdown reader and writer with a continuous feedback-learning system. The editor provides the daily reading and writing workspace. Saved editorial judgment enters SQLite immediately, synthesizes into reviewable writing rules, and exports as enforceable artifacts for future writing.
 
 Related docs:
 
@@ -25,13 +25,22 @@ Related docs:
 
 ## Critical Flows
 
+### Markdown Document Loop
+
+1. User opens a portable Markdown file or local article.
+2. TipTap renders it as a focused reading and writing surface.
+3. Formatting and edits serialize back to Markdown without losing supported structure.
+4. Saving writes the updated Markdown to its original local source.
+5. File watching and snapshots protect the editor from silent external-change loss.
+
 ### Annotation To Rule
 
-1. User annotates content in the Tauri app.
-2. Annotation data persists as corrections in SQLite.
-3. Corrections synthesize into writing rules.
-4. Rules export to `~/.margin/writing-rules.md` and `~/.claude/hooks/writing_guard.py`.
-5. Future AI writing is guided by the profile and constrained by the guard.
+1. User annotates content or records positive or corrective feedback.
+2. Saving feedback creates or updates the current unsynthesized correction in SQLite.
+3. Editing or deleting feedback updates that same pending signal.
+4. Synthesis turns correction events into reviewable writing rules.
+5. Approved rules export to `~/.margin/writing-rules.md` and `~/.claude/hooks/writing_guard.py`.
+6. Future writing uses the profile and guard, and the resulting prose returns to Margin for another review cycle.
 
 ### Agent Access
 

--- a/docs/evals.md
+++ b/docs/evals.md
@@ -55,6 +55,12 @@ Default is `full`.
 
 When relevant, also verify:
 
+- Markdown formatting controls preserve selection, expose pressed state, and serialize to the expected Markdown
+- reading and writing changes preserve cursor stability, save freshness, and supported Markdown round-trips
+- saved feedback appears in SQLite before any export action
+- disabling local learning prevents new correction rows without deleting prior learning data
+- editing feedback updates the current unsynthesized signal without duplicating it
+- feedback added after synthesis creates a new event
 - text anchoring behavior after edits
 - correction to rule to artifact chain integrity
 - parity between Rust-backed and MCP-backed generated artifacts
@@ -69,3 +75,4 @@ Changes are ready to hand off when:
 - any tier-specific behavioral risks were checked explicitly
 - new constraints or failure modes were documented in `docs/invariants.md` or `docs/troubleshooting.md`
 - production escapes, if any, are captured in `.harness/gaps.jsonl`
+- both product pillars were checked explicitly when a change touches their shared editor and feedback flow

--- a/docs/invariants.md
+++ b/docs/invariants.md
@@ -2,9 +2,11 @@
 
 ## Product Invariants
 
-- Margin exists to improve AI writing quality, not just to provide a pleasant reading UI.
-- The writing loop must remain intact: read, annotate, correct, synthesize rules, export artifacts, enforce on future writing.
-- High-friction or low-signal features are secondary to reliability of the writing-quality pipeline.
+- Margin has two peer pillars: a best-in-class Markdown reading and writing experience, and a system that continuously learns from feedback.
+- A change may strengthen one pillar, but it must not demote or silently damage the other.
+- The full loop must remain intact: read or write, give feedback, capture immediately, synthesize rules, review, apply, and measure.
+- Export is a distribution action. When local learning is enabled, saved correction feedback must already exist in SQLite before export.
+- Automatic capture must remain inspectable and reversible through Style Memory.
 
 ## Data Invariants
 
@@ -12,12 +14,14 @@
 - Schema truth originates in Rust migrations under `src-tauri/`; other surfaces must derive from that schema.
 - Generated artifacts such as `~/.margin/writing-rules.md` and `~/.claude/hooks/writing_guard.py` are derived outputs and must not become the primary source of truth.
 - Rule metadata such as `writing_type`, `register`, and `signal_count` must survive round-trips across app, MCP, and exports.
+- One unsynthesized correction row represents the current editable signal for a highlight. Feedback after synthesis creates a new event.
 
 ## Behavioral Invariants
 
 - Text anchoring must either preserve highlight position or surface a degraded state explicitly. Silent loss is not acceptable.
 - Pipeline failures should fail visible, not silent.
 - The writing guard should enforce hard constraints at the tool layer while remaining robust against malformed generated content.
+- Supported Markdown formatting must round-trip without cursor jumps or structural loss.
 
 ## Operational Invariants
 

--- a/docs/product-vision.md
+++ b/docs/product-vision.md
@@ -1,12 +1,12 @@
 # Product Vision — Margin
 
-**Last updated:** 2026-03-04
+**Last updated:** 2026-08-12
 
 ---
 
 ## One-liner
 
-AI writing is generic because LLMs have no memory of your taste. Margin fixes this — it captures editorial judgment from your reading and turns it into enforceable writing rules that make Claude write like you.
+Margin is a local-first Markdown reader and writer that learns from every editorial correction and applies the resulting rules to future work.
 
 ---
 
@@ -27,13 +27,23 @@ Nobody is building the feedback loop: **capture what you hate in AI writing → 
 
 ---
 
-## What Margin Actually Is
+## Two product pillars
 
-Margin is a writing quality system disguised as a reading app.
+Margin has two peer product pillars. Product decisions must strengthen at least one pillar without weakening the other.
 
-The surface is a desktop app where you open markdown files, highlight text, and write margin notes. That's the input mechanism. The actual product is underneath:
+### 1. Best-in-class Markdown reading and writing
 
-### 1. Structured capture of editorial judgment
+Margin should be the place a demanding writer wants to spend hours. Markdown files stay portable while the app supplies a calm reading canvas, fast editing, complete keyboard workflows, dependable formatting, strong typography, accurate round-tripping, search, navigation, and annotations that stay attached to the text.
+
+This experience is part of the product's value. Every correction begins with close reading or writing, so friction in the editor reduces both daily usefulness and the quality of the feedback Margin can learn from.
+
+### 2. Continuous learning from feedback
+
+Margin captures editorial judgment as it is saved. Local learning is on by default and can be disabled in Writing settings. Export distributes or shares feedback; it is no longer the step that turns feedback into learning data. The system keeps the current unsynthesized signal editable, preserves learned events after synthesis, and shows the user what it inferred before those rules govern future writing.
+
+The learning system has four parts:
+
+#### Structured capture of editorial judgment
 
 Every annotation carries metadata that generic highlighting tools don't capture:
 
@@ -44,7 +54,7 @@ Every annotation carries metadata that generic highlighting tools don't capture:
 
 When you highlight "leveraging cross-functional synergies" and write "corporate jargon — say what you mean," that isn't a bookmark. It's a training signal.
 
-### 2. Rule synthesis from accumulated corrections
+#### Rule synthesis from accumulated corrections
 
 Corrections synthesize into writing rules via Claude:
 
@@ -59,7 +69,7 @@ Source: synthesis
 
 Rules have categories (kill-words, ai-slop, voice-calibration, tone, structure), severities (must-fix, should-fix, nice-to-fix), and registers (casual, professional, universal). The collection of rules *is* the voice profile — a machine-readable specification of how you write.
 
-### 3. Enforcement on AI writing
+#### Enforcement on AI writing
 
 The voice profile generates two artifacts:
 
@@ -67,7 +77,7 @@ The voice profile generates two artifacts:
 
 - **`~/.claude/hooks/writing_guard.py`** — a pre-tool hook that intercepts Claude's Write and Edit operations on prose files. Kill-words and ai-slop patterns trigger automatic rejection. Claude literally cannot write "delve" into a markdown file if your rules say so.
 
-### 4. Verification that the loop works
+#### Verification that the loop works
 
 Adversarial testing infrastructure generates 27 prose samples (9 writing types x 3) using prompts designed to tempt AI tells. A two-layer compliance checker scores the output:
 
@@ -78,7 +88,7 @@ The regression suite diffs against baselines over time. If the compliance score 
 
 ### The loop
 
-**Read → Annotate → Correct → Synthesize rules → Enforce on AI writing → Read AI output → Annotate again.**
+**Read or write → Give feedback → Capture immediately → Synthesize rules → Review → Apply → Measure → Repeat.**
 
 Each iteration makes the system more precisely yours. The adversarial baseline proves it.
 
@@ -94,23 +104,31 @@ The common thread: they already use AI for writing, they already notice the tell
 
 ## Design Principles
 
-### 1. The writing output is the product, not the reading experience
+### 1. Treat both pillars as product quality
 
-Every feature is evaluated against: "Does this make AI write better prose?" A beautiful reading app that doesn't improve writing output is a failure. An ugly one that measurably reduces AI tells is a success.
+The Markdown experience earns daily use. The learning system compounds the value of that use. Evaluate each pillar independently and verify the full loop between them.
 
-### 2. Enforce, don't suggest
+### 2. Capture feedback at the moment of judgment
+
+A saved correction, positive signal, or rationale enters SQLite immediately. Editing the feedback updates the current unsynthesized signal. Feedback added after synthesis becomes a new event so repeated judgment remains countable.
+
+### 3. Keep learning legible and reversible
+
+Users can inspect the corrections behind a rule, edit or reject the rule, and understand where it applies. Automatic capture does not authorize opaque or irreversible changes to the voice profile.
+
+### 4. Enforce approved rules
 
 Grammarly suggests. Writing guides advise. Margin enforces. The writing guard is a binary gate: Claude cannot write kill-words into prose files. This is stronger than any prompt instruction because it operates at the tool level, not the prompt level. The AI doesn't choose to comply — it's mechanically prevented from violating.
 
-### 3. Verify the loop, not just the plumbing
+### 5. Verify outcomes across the full loop
 
 It's not enough that annotations flow into rules that flow into profiles. The product hypothesis — that accumulated editorial judgment makes AI write measurably better prose — must be tested adversarially. Compliance scoring and regression baselines are product features.
 
-### 4. Database is the source of truth
+### 6. Database is the source of truth
 
 Rules live in SQLite, not in markdown files or prompt templates. The generated artifacts (`writing-rules.md`, `writing_guard.py`) are derived from the database. This means rules are queryable, countable, versioned, and accessible from multiple surfaces (desktop app, MCP tools, CLI).
 
-### 5. Local-first because editorial judgment is private
+### 7. Local-first because editorial judgment is private
 
 Your writing rules are a fingerprint. What you flag, what you fix, what you admire — this is the most personal data an AI tool could hold. It lives on your machine in SQLite. No cloud account. No sync service. No sending your editorial taste to a server.
 
@@ -164,6 +182,14 @@ Tools that don't compete with Margin but share adjacent design instincts worth s
 ---
 
 ## What Success Looks Like
+
+### Reading and writing feels complete
+
+Opening a Markdown file, navigating it, editing prose, applying common formatting, saving, and returning to the same place should be fast and dependable. Round-trip tests must preserve Markdown meaning, and primary actions must work from the keyboard.
+
+### Feedback becomes learning data immediately
+
+Saving or editing correction feedback updates the current unsynthesized signal in SQLite without an export step. Style Memory shows the new signal and keeps its path into a reviewed rule inspectable.
 
 ### The adversarial score improves over time
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -84,7 +84,7 @@ The outer shell is using a different Node runtime than the package-local runtime
 
 Run MCP commands with the matching Node 22 runtime:
 
-- `MCP_NODE_BIN=/opt/homebrew/Cellar/node@22/22.22.0_1/bin/node bash scripts/verify standard`
+- `MCP_NODE_BIN=/opt/homebrew/opt/node@22/bin/node bash scripts/verify standard`
 - or invoke the `mcp` test/build entrypoints directly with that Node binary
 
 If needed, confirm the local runtime with:

--- a/scripts/verify
+++ b/scripts/verify
@@ -48,7 +48,7 @@ require_cmd() {
 
 run_mcp_command() {
   local mcp_dir="$REPO_ROOT/mcp"
-  local node_bin="${MCP_NODE_BIN:-/opt/homebrew/Cellar/node@22/22.22.0_1/bin/node}"
+  local node_bin="${MCP_NODE_BIN:-/opt/homebrew/opt/node@22/bin/node}"
   local vitest_entry="$REPO_ROOT/node_modules/.pnpm/vitest@3.2.4_@types+node@22.19.13_jiti@2.6.1_jsdom@28.1.0_lightningcss@1.31.1/node_modules/vitest/vitest.mjs"
   local tsc_entry="$REPO_ROOT/node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/bin/tsc"
   local subcommand="$1"

--- a/src-tauri/src/commands/annotations.rs
+++ b/src-tauri/src/commands/annotations.rs
@@ -1,4 +1,5 @@
 use crate::commands::now_millis;
+use crate::commands::feedback::sync_continuous_feedback;
 use crate::db::migrations::DbPool;
 use crate::db::models::{Highlight, MarginNote};
 use rusqlite::Connection;
@@ -275,8 +276,10 @@ pub async fn create_margin_note(
     highlight_id: String,
     content: String,
     intent: Option<String>,
+    capture_feedback: Option<bool>,
 ) -> Result<MarginNote, String> {
     let conn = state.0.lock().unwrap_or_else(|e| e.into_inner());
+    let tx = conn.unchecked_transaction().map_err(|e| e.to_string())?;
     let id = Uuid::new_v4().to_string();
     let now = now_millis();
     let intent = intent.unwrap_or_else(|| "correction".to_string());
@@ -286,10 +289,14 @@ pub async fn create_margin_note(
         ));
     }
 
-    insert_margin_note_with_intent(&conn, &id, &highlight_id, &content, &intent, now)?;
+    insert_margin_note_with_intent(&tx, &id, &highlight_id, &content, &intent, now)?;
 
-    let doc_id = document_id_for_highlight(&conn, &highlight_id)?;
-    touch_document(&conn, &doc_id)?;
+    let doc_id = document_id_for_highlight(&tx, &highlight_id)?;
+    if intent == "correction" && capture_feedback.unwrap_or(false) {
+        sync_continuous_feedback(&tx, &highlight_id, None, None, now)?;
+    }
+    touch_document(&tx, &doc_id)?;
+    tx.commit().map_err(|e| e.to_string())?;
 
     Ok(MarginNote {
         id,
@@ -308,24 +315,54 @@ pub async fn get_margin_notes(state: tauri::State<'_, DbPool>, document_id: Stri
 }
 
 #[tauri::command]
-pub async fn update_margin_note(state: tauri::State<'_, DbPool>, id: String, content: String) -> Result<(), String> {
+pub async fn update_margin_note(
+    state: tauri::State<'_, DbPool>,
+    id: String,
+    content: String,
+    capture_feedback: Option<bool>,
+) -> Result<(), String> {
     let conn = state.0.lock().unwrap_or_else(|e| e.into_inner());
+    let tx = conn.unchecked_transaction().map_err(|e| e.to_string())?;
     let now = now_millis();
 
-    let doc_id = document_id_for_margin_note(&conn, &id)?;
-    set_margin_note_content(&conn, &id, &content, now)?;
-    touch_document(&conn, &doc_id)?;
+    let highlight_id: String = tx.query_row(
+        "SELECT highlight_id FROM margin_notes WHERE id = ?1",
+        [&id],
+        |row| row.get(0),
+    ).map_err(|e| e.to_string())?;
+    let doc_id = document_id_for_margin_note(&tx, &id)?;
+    set_margin_note_content(&tx, &id, &content, now)?;
+    if capture_feedback.unwrap_or(false) {
+        sync_continuous_feedback(&tx, &highlight_id, None, None, now)?;
+    }
+    touch_document(&tx, &doc_id)?;
+    tx.commit().map_err(|e| e.to_string())?;
 
     Ok(())
 }
 
 #[tauri::command]
-pub async fn delete_margin_note(state: tauri::State<'_, DbPool>, id: String) -> Result<(), String> {
+pub async fn delete_margin_note(
+    state: tauri::State<'_, DbPool>,
+    id: String,
+    capture_feedback: Option<bool>,
+) -> Result<(), String> {
     let conn = state.0.lock().unwrap_or_else(|e| e.into_inner());
+    let tx = conn.unchecked_transaction().map_err(|e| e.to_string())?;
+    let now = now_millis();
 
-    let doc_id = document_id_for_margin_note(&conn, &id)?;
-    remove_margin_note(&conn, &id)?;
-    touch_document(&conn, &doc_id)?;
+    let highlight_id: String = tx.query_row(
+        "SELECT highlight_id FROM margin_notes WHERE id = ?1",
+        [&id],
+        |row| row.get(0),
+    ).map_err(|e| e.to_string())?;
+    let doc_id = document_id_for_margin_note(&tx, &id)?;
+    remove_margin_note(&tx, &id)?;
+    if capture_feedback.unwrap_or(false) {
+        sync_continuous_feedback(&tx, &highlight_id, None, None, now)?;
+    }
+    touch_document(&tx, &doc_id)?;
+    tx.commit().map_err(|e| e.to_string())?;
 
     Ok(())
 }

--- a/src-tauri/src/commands/corrections.rs
+++ b/src-tauri/src/commands/corrections.rs
@@ -1,7 +1,7 @@
 use crate::commands::now_millis;
 use crate::db::migrations::DbPool;
 use crate::db::models::CorrectionInput;
-use rusqlite::Connection;
+use rusqlite::{Connection, OptionalExtension};
 use std::fs;
 use std::io::Write;
 use std::path::Path;
@@ -240,42 +240,53 @@ fn persist_corrections_inner(
             }
         }
 
-        let id = Uuid::new_v4().to_string();
         let notes_json = serde_json::to_string(&input.notes).map_err(|e| e.to_string())?;
+        let existing_id = tx.query_row(
+            "SELECT id FROM corrections
+             WHERE highlight_id = ?1 AND synthesized_at IS NULL
+             ORDER BY created_at DESC LIMIT 1",
+            [&input.highlight_id],
+            |row| row.get::<_, String>(0),
+        ).optional().map_err(|e| e.to_string())?;
 
-        tx.execute(
-            "INSERT INTO corrections
-                (id, highlight_id, document_id, session_id, original_text,
-                 prefix_context, suffix_context, extended_context, notes_json,
-                 document_title, document_source, document_path, category,
-                 highlight_color, created_at, updated_at, writing_type, polarity, feedback_type,
-                 suggested_edit, rationale)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21)",
-            rusqlite::params![
-                id,
-                input.highlight_id,
-                document_id,
-                session_id,
-                input.original_text,
-                input.prefix_context,
-                input.suffix_context,
-                input.extended_context,
-                notes_json,
-                document_title,
-                document_source,
-                document_path,
-                Option::<String>::None, // category
-                input.highlight_color,
-                now,
-                now,
-                input.writing_type,
-                input.polarity,
-                input.feedback_type,
-                input.suggested_edit,
-                input.rationale,
-            ],
-        )
-        .map_err(|e| e.to_string())?;
+        if let Some(existing_id) = existing_id {
+            tx.execute(
+                "UPDATE corrections
+                 SET document_id = ?1, session_id = ?2, original_text = ?3,
+                     prefix_context = ?4, suffix_context = ?5, extended_context = ?6,
+                     notes_json = ?7, document_title = ?8, document_source = ?9,
+                     document_path = ?10, highlight_color = ?11, updated_at = ?12,
+                     writing_type = ?13, polarity = ?14, feedback_type = ?15,
+                     suggested_edit = ?16, rationale = ?17
+                 WHERE id = ?18",
+                rusqlite::params![
+                    document_id, session_id, input.original_text, input.prefix_context,
+                    input.suffix_context, input.extended_context, notes_json,
+                    document_title, document_source, document_path, input.highlight_color,
+                    now, input.writing_type, input.polarity, input.feedback_type,
+                    input.suggested_edit, input.rationale, existing_id,
+                ],
+            ).map_err(|e| e.to_string())?;
+        } else {
+            tx.execute(
+                "INSERT INTO corrections
+                    (id, highlight_id, document_id, session_id, original_text,
+                     prefix_context, suffix_context, extended_context, notes_json,
+                     document_title, document_source, document_path, category,
+                     highlight_color, created_at, updated_at, writing_type, polarity, feedback_type,
+                     suggested_edit, rationale)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21)",
+                rusqlite::params![
+                    Uuid::new_v4().to_string(), input.highlight_id, document_id,
+                    session_id, input.original_text, input.prefix_context,
+                    input.suffix_context, input.extended_context, notes_json,
+                    document_title, document_source, document_path,
+                    Option::<String>::None, input.highlight_color, now, now,
+                    input.writing_type, input.polarity, input.feedback_type,
+                    input.suggested_edit, input.rationale,
+                ],
+            ).map_err(|e| e.to_string())?;
+        }
         correction_count += 1;
 
         // Append JSONL record
@@ -1168,6 +1179,43 @@ mod tests {
         let sidecar = fs::read_to_string(prompt_sidecar).unwrap();
         assert!(sidecar.contains("Turn this into a prompt"));
         assert!(!sidecar.contains("Save this thought"));
+    }
+
+    #[test]
+    fn export_enriches_an_unsynthesized_signal_without_duplication() {
+        let conn = setup_full_db();
+        let out_dir = tempfile::tempdir().unwrap();
+        insert_correction(&conn, "h1", "weak sentence", r#"["Use evidence."]"#);
+        let inputs = vec![CorrectionInput {
+            highlight_id: "h1".to_string(),
+            original_text: "weak sentence".to_string(),
+            prefix_context: None,
+            suffix_context: None,
+            extended_context: Some("Wider context".to_string()),
+            notes: vec!["Use evidence.".to_string()],
+            highlight_color: "yellow".to_string(),
+            writing_type: Some("blog".to_string()),
+            polarity: Some("corrective".to_string()),
+            feedback_type: None,
+            intent: "correction".to_string(),
+            suggested_edit: None,
+            rationale: Some("Readers need proof.".to_string()),
+        }];
+
+        persist_corrections_inner(
+            &conn, &inputs, "doc1", Some("Test"), "file", None,
+            "2026-08-12", out_dir.path(),
+        ).unwrap();
+
+        let captured: (i64, Option<String>, Option<String>) = conn.query_row(
+            "SELECT COUNT(*), MAX(writing_type), MAX(rationale)
+             FROM corrections WHERE highlight_id = 'h1'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        ).unwrap();
+        assert_eq!(captured.0, 1);
+        assert_eq!(captured.1.as_deref(), Some("blog"));
+        assert_eq!(captured.2.as_deref(), Some("Readers need proof."));
     }
 
     #[test]

--- a/src-tauri/src/commands/feedback.rs
+++ b/src-tauri/src/commands/feedback.rs
@@ -1,0 +1,310 @@
+use crate::commands::now_millis;
+use crate::db::migrations::DbPool;
+use rusqlite::{Connection, OptionalExtension};
+use uuid::Uuid;
+
+#[derive(Debug)]
+struct FeedbackSource {
+    document_id: String,
+    original_text: String,
+    prefix_context: Option<String>,
+    suffix_context: Option<String>,
+    highlight_color: String,
+    document_title: Option<String>,
+    document_source: String,
+    document_path: Option<String>,
+}
+
+/// Keep one mutable row for feedback that has not entered synthesis yet.
+/// Feedback saved after synthesis becomes a new event.
+pub(crate) fn sync_continuous_feedback(
+    conn: &Connection,
+    highlight_id: &str,
+    polarity_patch: Option<Option<&str>>,
+    rationale_patch: Option<Option<&str>>,
+    now: i64,
+) -> Result<bool, String> {
+    if let Some(Some(polarity)) = polarity_patch {
+        if !matches!(polarity, "positive" | "corrective") {
+            return Err(format!(
+                "invalid polarity: {polarity:?} (expected \"positive\" or \"corrective\")"
+            ));
+        }
+    }
+
+    let source = conn
+        .query_row(
+            "SELECT h.document_id, h.text_content, h.prefix_context, h.suffix_context,
+                h.color, d.title, d.source, d.file_path
+         FROM highlights h
+         JOIN documents d ON d.id = h.document_id
+         WHERE h.id = ?1",
+            [highlight_id],
+            |row| {
+                Ok(FeedbackSource {
+                    document_id: row.get(0)?,
+                    original_text: row.get(1)?,
+                    prefix_context: row.get(2)?,
+                    suffix_context: row.get(3)?,
+                    highlight_color: row.get(4)?,
+                    document_title: row.get(5)?,
+                    document_source: row.get(6)?,
+                    document_path: row.get(7)?,
+                })
+            },
+        )
+        .map_err(|e| e.to_string())?;
+
+    if source.original_text.trim().is_empty() {
+        return Err("empty highlight text is not allowed for continuous feedback".to_string());
+    }
+
+    let notes = {
+        let mut stmt = conn
+            .prepare(
+                "SELECT content FROM margin_notes
+             WHERE highlight_id = ?1 AND intent = 'correction'
+             ORDER BY created_at, id",
+            )
+            .map_err(|e| e.to_string())?;
+        let rows = stmt
+            .query_map([highlight_id], |row| row.get::<_, String>(0))
+            .map_err(|e| e.to_string())?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| e.to_string())?;
+        rows
+    };
+
+    let existing = conn
+        .query_row(
+            "SELECT id, polarity, rationale
+         FROM corrections
+         WHERE highlight_id = ?1 AND synthesized_at IS NULL
+         ORDER BY created_at DESC LIMIT 1",
+            [highlight_id],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, Option<String>>(1)?,
+                    row.get::<_, Option<String>>(2)?,
+                ))
+            },
+        )
+        .optional()
+        .map_err(|e| e.to_string())?;
+
+    let existing_polarity = existing.as_ref().and_then(|(_, value, _)| value.clone());
+    let existing_rationale = existing.as_ref().and_then(|(_, _, value)| value.clone());
+    let polarity = match polarity_patch {
+        Some(value) => value.map(str::to_owned),
+        None => existing_polarity,
+    };
+    let rationale = match rationale_patch {
+        Some(value) => value
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_owned),
+        None => existing_rationale,
+    };
+
+    if notes.is_empty() && polarity.is_none() && rationale.is_none() {
+        if let Some((id, _, _)) = existing {
+            conn.execute("DELETE FROM corrections WHERE id = ?1", [id])
+                .map_err(|e| e.to_string())?;
+            return Ok(true);
+        }
+        return Ok(false);
+    }
+
+    let notes_json = serde_json::to_string(&notes).map_err(|e| e.to_string())?;
+    let extended_context = if source.prefix_context.is_some() || source.suffix_context.is_some() {
+        Some(format!(
+            "{}{}{}",
+            source.prefix_context.as_deref().unwrap_or_default(),
+            source.original_text,
+            source.suffix_context.as_deref().unwrap_or_default()
+        ))
+    } else {
+        None
+    };
+
+    if let Some((id, _, _)) = existing {
+        conn.execute(
+            "UPDATE corrections
+             SET document_id = ?1, original_text = ?2, prefix_context = ?3,
+                 suffix_context = ?4, extended_context = ?5, notes_json = ?6,
+                 document_title = ?7, document_source = ?8, document_path = ?9,
+                 highlight_color = ?10, polarity = ?11, rationale = ?12, updated_at = ?13
+             WHERE id = ?14",
+            rusqlite::params![
+                source.document_id,
+                source.original_text,
+                source.prefix_context,
+                source.suffix_context,
+                extended_context,
+                notes_json,
+                source.document_title,
+                source.document_source,
+                source.document_path,
+                source.highlight_color,
+                polarity,
+                rationale,
+                now,
+                id,
+            ],
+        )
+        .map_err(|e| e.to_string())?;
+    } else {
+        conn.execute(
+            "INSERT INTO corrections
+                (id, highlight_id, document_id, session_id, original_text,
+                 prefix_context, suffix_context, extended_context, notes_json,
+                 document_title, document_source, document_path, highlight_color,
+                 created_at, updated_at, polarity, rationale)
+             VALUES (?1, ?2, ?3, 'continuous', ?4, ?5, ?6, ?7, ?8, ?9, ?10,
+                     ?11, ?12, ?13, ?13, ?14, ?15)",
+            rusqlite::params![
+                Uuid::new_v4().to_string(),
+                highlight_id,
+                source.document_id,
+                source.original_text,
+                source.prefix_context,
+                source.suffix_context,
+                extended_context,
+                notes_json,
+                source.document_title,
+                source.document_source,
+                source.document_path,
+                source.highlight_color,
+                now,
+                polarity,
+                rationale,
+            ],
+        )
+        .map_err(|e| e.to_string())?;
+    }
+
+    Ok(true)
+}
+
+#[tauri::command]
+pub async fn sync_feedback_signal(
+    state: tauri::State<'_, DbPool>,
+    highlight_id: String,
+    polarity: Option<String>,
+    rationale: Option<String>,
+) -> Result<bool, String> {
+    let conn = state.0.lock().unwrap_or_else(|e| e.into_inner());
+    sync_continuous_feedback(
+        &conn,
+        &highlight_id,
+        Some(polarity.as_deref()),
+        Some(rationale.as_deref()),
+        now_millis(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn setup_db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE documents (id TEXT PRIMARY KEY, source TEXT NOT NULL, file_path TEXT, title TEXT);
+             CREATE TABLE highlights (
+                id TEXT PRIMARY KEY, document_id TEXT NOT NULL, color TEXT NOT NULL,
+                text_content TEXT NOT NULL, prefix_context TEXT, suffix_context TEXT
+             );
+             CREATE TABLE margin_notes (
+                id TEXT PRIMARY KEY, highlight_id TEXT NOT NULL, content TEXT NOT NULL,
+                intent TEXT NOT NULL, created_at INTEGER NOT NULL
+             );
+             CREATE TABLE corrections (
+                id TEXT PRIMARY KEY, highlight_id TEXT NOT NULL, document_id TEXT NOT NULL,
+                session_id TEXT NOT NULL, original_text TEXT NOT NULL, prefix_context TEXT,
+                suffix_context TEXT, extended_context TEXT, notes_json TEXT NOT NULL,
+                document_title TEXT, document_source TEXT NOT NULL, document_path TEXT,
+                category TEXT, highlight_color TEXT NOT NULL, created_at INTEGER NOT NULL,
+                updated_at INTEGER NOT NULL, writing_type TEXT, polarity TEXT,
+                synthesized_at INTEGER, feedback_type TEXT, suggested_edit TEXT,
+                accepted_at INTEGER, rationale TEXT
+             );
+             INSERT INTO documents VALUES ('doc1', 'file', '/tmp/test.md', 'Test document');
+             INSERT INTO highlights VALUES (
+                'h1', 'doc1', 'yellow', 'weak sentence', 'Before. ', ' After.'
+             );",
+        ).unwrap();
+        conn
+    }
+
+    fn add_note(conn: &Connection, id: &str, content: &str, created_at: i64) {
+        conn.execute(
+            "INSERT INTO margin_notes VALUES (?1, 'h1', ?2, 'correction', ?3)",
+            rusqlite::params![id, content, created_at],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn captures_feedback_without_export() {
+        let conn = setup_db();
+        add_note(&conn, "n1", "Use a concrete example.", 1000);
+
+        sync_continuous_feedback(
+            &conn,
+            "h1",
+            Some(Some("corrective")),
+            Some(Some("The claim needs proof.")),
+            2000,
+        )
+        .unwrap();
+
+        let captured: (String, String, Option<String>) = conn
+            .query_row(
+                "SELECT original_text, notes_json, polarity FROM corrections",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(captured.0, "weak sentence");
+        assert_eq!(captured.1, r#"["Use a concrete example."]"#);
+        assert_eq!(captured.2.as_deref(), Some("corrective"));
+    }
+
+    #[test]
+    fn updates_the_current_unsynthesized_signal() {
+        let conn = setup_db();
+        add_note(&conn, "n1", "First note.", 1000);
+        sync_continuous_feedback(&conn, "h1", None, None, 2000).unwrap();
+        add_note(&conn, "n2", "Second note.", 2001);
+        sync_continuous_feedback(&conn, "h1", Some(Some("positive")), None, 3000).unwrap();
+
+        let captured: (i64, String, Option<String>) = conn
+            .query_row(
+                "SELECT COUNT(*), MAX(notes_json), MAX(polarity) FROM corrections",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(captured.0, 1);
+        assert_eq!(captured.1, r#"["First note.","Second note."]"#);
+        assert_eq!(captured.2.as_deref(), Some("positive"));
+    }
+
+    #[test]
+    fn starts_a_new_event_after_synthesis() {
+        let conn = setup_db();
+        add_note(&conn, "n1", "First note.", 1000);
+        sync_continuous_feedback(&conn, "h1", None, None, 2000).unwrap();
+        conn.execute("UPDATE corrections SET synthesized_at = 2500", [])
+            .unwrap();
+        add_note(&conn, "n2", "New feedback.", 3000);
+        sync_continuous_feedback(&conn, "h1", None, None, 4000).unwrap();
+
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM corrections", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(count, 2);
+    }
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -3,6 +3,7 @@ pub mod corrections;
 pub mod dashboard;
 pub mod documents;
 pub mod files;
+pub mod feedback;
 pub mod keep_local;
 pub mod search;
 pub mod seed_rules;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -67,6 +67,7 @@ pub fn run() {
             commands::corrections::persist_corrections,
             commands::corrections::get_all_corrections,
             commands::corrections::get_corrections_count,
+            commands::feedback::sync_feedback_signal,
             commands::corrections::get_corrections_by_document,
             commands::corrections::update_correction_writing_type,
             commands::corrections::delete_correction,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,7 +29,7 @@ import { applyAcceptedCorrection } from "@/lib/apply-accepted-correction";
 import { buildCorrectionExportInputs, formatAnnotationsMarkdown, getExtendedContext } from "@/lib/export-annotations";
 import { serializeEditorMarkdown } from "@/lib/serialize-editor";
 import { shouldClearAnnotationsAfterExport } from "@/lib/export-clear-policy";
-import { readFile, drainPendingOpenFiles, persistCorrections, exportWritingRules, markHighlightsExported } from "@/lib/tauri-commands";
+import { readFile, drainPendingOpenFiles, persistCorrections, exportWritingRules, markHighlightsExported, syncFeedbackSignal } from "@/lib/tauri-commands";
 import { listen } from "@tauri-apps/api/event";
 import { stat } from "@tauri-apps/plugin-fs";
 import { getCurrentWindow } from "@tauri-apps/api/window";
@@ -108,7 +108,7 @@ const showUIFork = import.meta.env.MODE !== "production";
 export default function App() {
   const { settings, setSetting } = useSettings();
   const doc = useDocument();
-  const annotations = useAnnotations(doc.refreshRecentDocs);
+  const annotations = useAnnotations(doc.refreshRecentDocs, settings.persistCorrections);
   const keepLocal = useKeepLocal();
   const search = useSearch();
   const onboarding = useOnboarding();
@@ -1320,9 +1320,33 @@ export default function App() {
             notes={notes}
             polarity={polarityMap.get(highlight.id) ?? null}
             rationale={rationaleMap.get(highlight.id) ?? null}
-            onAddNote={annotations.createMarginNoteWithIntent}
-            onUpdateNote={annotations.updateMarginNote}
-            onDeleteNote={annotations.deleteMarginNote}
+            onAddNote={(highlightId, content, intent) => {
+              void annotations.createMarginNoteWithIntent(highlightId, content, intent).catch((err: unknown) => {
+                console.error("Failed to save feedback note:", err);
+                setErrorToast({
+                  message: `Could not save feedback: ${err instanceof Error ? err.message : String(err)}`,
+                  id: ++errorIdRef.current,
+                });
+              });
+            }}
+            onUpdateNote={(noteId, content) => {
+              void annotations.updateMarginNote(noteId, content).catch((err: unknown) => {
+                console.error("Failed to update feedback note:", err);
+                setErrorToast({
+                  message: `Could not update feedback: ${err instanceof Error ? err.message : String(err)}`,
+                  id: ++errorIdRef.current,
+                });
+              });
+            }}
+            onDeleteNote={(noteId) => {
+              void annotations.deleteMarginNote(noteId).catch((err: unknown) => {
+                console.error("Failed to delete feedback note:", err);
+                setErrorToast({
+                  message: `Could not delete feedback: ${err instanceof Error ? err.message : String(err)}`,
+                  id: ++errorIdRef.current,
+                });
+              });
+            }}
             onDeleteHighlight={handleDeleteHighlight}
             onSetPolarity={(highlightId, polarity) => {
               setPolarityMap((prev) => {
@@ -1334,6 +1358,18 @@ export default function App() {
                 }
                 return next;
               });
+              if (!settings.persistCorrections) return;
+              void syncFeedbackSignal(
+                highlightId,
+                polarity,
+                rationaleMap.get(highlightId) ?? null,
+              ).catch((err: unknown) => {
+                console.error("Failed to capture feedback polarity:", err);
+                setErrorToast({
+                  message: `Could not save feedback: ${err instanceof Error ? err.message : String(err)}`,
+                  id: ++errorIdRef.current,
+                });
+              });
             }}
             onUpdateRationale={(highlightId, rationale) => {
               setRationaleMap((prev) => {
@@ -1344,6 +1380,18 @@ export default function App() {
                   next.set(highlightId, rationale);
                 }
                 return next;
+              });
+              if (!settings.persistCorrections) return;
+              void syncFeedbackSignal(
+                highlightId,
+                polarityMap.get(highlightId) ?? null,
+                rationale,
+              ).catch((err: unknown) => {
+                console.error("Failed to capture feedback rationale:", err);
+                setErrorToast({
+                  message: `Could not save feedback: ${err instanceof Error ? err.message : String(err)}`,
+                  id: ++errorIdRef.current,
+                });
               });
             }}
             onClose={() => {

--- a/src/components/editor/FloatingToolbar.v1.tsx
+++ b/src/components/editor/FloatingToolbar.v1.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback, useRef, type CSSProperties } from "react";
 import { createPortal } from "react-dom";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { Comment01Icon } from "@hugeicons/core-free-icons";
@@ -13,6 +13,21 @@ interface FloatingToolbarProps {
   defaultColor?: string;
 }
 
+type InlineFormat = "bold" | "italic" | "strike" | "code";
+
+const INLINE_FORMATS: Array<{
+  format: InlineFormat;
+  label: string;
+  shortcut?: string;
+  glyph: string;
+  style?: CSSProperties;
+}> = [
+  { format: "bold", label: "Bold", shortcut: "⌘B", glyph: "B", style: { fontWeight: 700 } },
+  { format: "italic", label: "Italic", shortcut: "⌘I", glyph: "I", style: { fontStyle: "italic" } },
+  { format: "strike", label: "Strikethrough", glyph: "S", style: { textDecoration: "line-through" } },
+  { format: "code", label: "Inline code", glyph: "<>" },
+];
+
 export function FloatingToolbar({
   editor,
   onHighlight,
@@ -25,6 +40,25 @@ export function FloatingToolbar({
   const [isFlipped, setIsFlipped] = useState(false);
   const toolbarRef = useRef<HTMLDivElement>(null);
   const noteSelectionRef = useRef<{ from: number; to: number } | null>(null);
+
+  const applyInlineFormat = useCallback((format: InlineFormat) => {
+    if (!editor) return;
+    const chain = editor.chain().focus();
+    switch (format) {
+      case "bold":
+        chain.toggleBold().run();
+        break;
+      case "italic":
+        chain.toggleItalic().run();
+        break;
+      case "strike":
+        chain.toggleStrike().run();
+        break;
+      case "code":
+        chain.toggleCode().run();
+        break;
+    }
+  }, [editor]);
 
   const currentSelectionRange = useCallback(() => {
     if (!editor) return null;
@@ -133,7 +167,7 @@ export function FloatingToolbar({
     <div
       ref={toolbarRef}
       role="toolbar"
-      aria-label="Text formatting"
+      aria-label="Formatting and feedback"
       className="fixed z-50 flex items-center gap-1 border px-2 py-1.5 shadow-md"
       style={{
         top: position.top,
@@ -153,6 +187,45 @@ export function FloatingToolbar({
         e.preventDefault();
       }}
     >
+      {INLINE_FORMATS.map(({ format, label, shortcut, glyph, style }) => {
+        const isActive = editor.isActive(format);
+        return (
+          <button
+            key={format}
+            type="button"
+            onClick={() => applyInlineFormat(format)}
+            className={`toolbar-btn${isActive ? " toolbar-btn--active" : ""}`}
+            aria-label={`${label}${shortcut ? ` (${shortcut})` : ""}`}
+            aria-pressed={isActive}
+            title={`${label}${shortcut ? ` ${shortcut}` : ""}`}
+          >
+            <span
+              aria-hidden="true"
+              style={{
+                minWidth: 18,
+                fontFamily: format === "code" ? "var(--font-mono, ui-monospace, monospace)" : "var(--font-sans, system-ui, sans-serif)",
+                fontSize: format === "code" ? 12 : 15,
+                lineHeight: 1,
+                ...style,
+              }}
+            >
+              {glyph}
+            </span>
+          </button>
+        );
+      })}
+
+      <div
+        aria-hidden="true"
+        style={{
+          width: 1,
+          height: 18,
+          backgroundColor: "var(--color-border)",
+          margin: "0 2px",
+          flexShrink: 0,
+        }}
+      />
+
       {/* Color picker circles — default color first */}
       {[...HIGHLIGHT_COLORS].sort((a, b) =>
         a.name === defaultColor ? -1 : b.name === defaultColor ? 1 : 0

--- a/src/components/editor/__tests__/FloatingToolbar.test.tsx
+++ b/src/components/editor/__tests__/FloatingToolbar.test.tsx
@@ -16,6 +16,12 @@ import { FloatingToolbar } from "../FloatingToolbar";
 // Minimal Editor mock with the events and state the toolbar needs
 function createMockEditor(hasSelection: boolean) {
   const listeners: Record<string, Array<() => void>> = {};
+  const run = vi.fn();
+  const toggleBold = vi.fn(() => ({ run }));
+  const toggleItalic = vi.fn(() => ({ run }));
+  const toggleStrike = vi.fn(() => ({ run }));
+  const toggleCode = vi.fn(() => ({ run }));
+  const focus = vi.fn(() => ({ toggleBold, toggleItalic, toggleStrike, toggleCode }));
   return {
     state: {
       selection: { empty: !hasSelection, from: 0, to: hasSelection ? 10 : 0 },
@@ -24,6 +30,8 @@ function createMockEditor(hasSelection: boolean) {
     view: {
       coordsAtPos: () => ({ top: 100, bottom: 120, left: 50, right: 150 }),
     },
+    chain: () => ({ focus }),
+    isActive: vi.fn(() => false),
     on: (event: string, fn: () => void) => {
       (listeners[event] ??= []).push(fn);
     },
@@ -37,6 +45,7 @@ function createMockEditor(hasSelection: boolean) {
     _trigger: (event: string) => {
       for (const fn of listeners[event] ?? []) fn();
     },
+    _formatting: { focus, toggleBold, toggleItalic, toggleStrike, toggleCode, run },
   } as unknown as import("@tiptap/core").Editor & { _trigger: (e: string) => void };
 }
 
@@ -61,7 +70,7 @@ describe("FloatingToolbar", () => {
 
       const toolbar = document.body.querySelector("[role='toolbar']");
       expect(toolbar).toBeTruthy();
-      expect(toolbar?.getAttribute("aria-label")).toBe("Text formatting");
+      expect(toolbar?.getAttribute("aria-label")).toBe("Formatting and feedback");
     } finally {
       vi.useRealTimers();
     }
@@ -209,6 +218,51 @@ describe("FloatingToolbar", () => {
       fireEvent.click(noteButton);
 
       expect(onNote).toHaveBeenCalledWith({ from: 3, to: 8 });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("offers Markdown formatting without leaving the selection", async () => {
+    vi.useFakeTimers();
+    try {
+      const editor = createMockEditor(true) as unknown as import("@tiptap/core").Editor & {
+        _trigger: (event: string) => void;
+        _formatting: {
+          focus: ReturnType<typeof vi.fn>;
+          toggleBold: ReturnType<typeof vi.fn>;
+          run: ReturnType<typeof vi.fn>;
+        };
+      };
+
+      render(
+        <FloatingToolbar
+          editor={editor}
+          onHighlight={vi.fn()}
+          onNote={vi.fn()}
+        />,
+      );
+
+      await act(async () => {
+        editor._trigger("selectionUpdate");
+        vi.runAllTimers();
+      });
+
+      const bold = document.body.querySelector("[aria-label='Bold (⌘B)']") as HTMLButtonElement;
+      const italic = document.body.querySelector("[aria-label='Italic (⌘I)']");
+      const strike = document.body.querySelector("[aria-label='Strikethrough']");
+      const code = document.body.querySelector("[aria-label='Inline code']");
+
+      expect(bold).toBeTruthy();
+      expect(italic).toBeTruthy();
+      expect(strike).toBeTruthy();
+      expect(code).toBeTruthy();
+
+      fireEvent.click(bold);
+
+      expect(editor._formatting.focus).toHaveBeenCalledOnce();
+      expect(editor._formatting.toggleBold).toHaveBeenCalledOnce();
+      expect(editor._formatting.run).toHaveBeenCalledOnce();
     } finally {
       vi.useRealTimers();
     }

--- a/src/components/settings/WritingSection.tsx
+++ b/src/components/settings/WritingSection.tsx
@@ -19,8 +19,8 @@ export function WritingSection({
         <SectionHeader title="Writing" />
 
         <SettingRow
-          label="Remember corrections"
-          description="Store highlights and notes in local database when exporting"
+          label="Learn from feedback"
+          description="Save correction feedback to Margin's local learning system as you write"
         >
           <ToggleSwitch
             checked={settings.persistCorrections}

--- a/src/components/settings/__tests__/SettingsPage.test.tsx
+++ b/src/components/settings/__tests__/SettingsPage.test.tsx
@@ -71,7 +71,7 @@ describe("SettingsPage", () => {
     fireEvent.click(screen.getByText("Writing"));
 
     // Writing section content should now be visible
-    expect(screen.getByText("Remember corrections")).toBeInTheDocument();
+    expect(screen.getByText("Learn from feedback")).toBeInTheDocument();
   });
 
   it("escape key closes settings", () => {

--- a/src/components/settings/__tests__/WritingSection.test.tsx
+++ b/src/components/settings/__tests__/WritingSection.test.tsx
@@ -13,7 +13,8 @@ describe("WritingSection", () => {
   it("renders persist corrections toggle", () => {
     render(<WritingSection {...defaultProps} />);
 
-    expect(screen.getByText("Remember corrections")).toBeInTheDocument();
+    expect(screen.getByText("Learn from feedback")).toBeInTheDocument();
+    expect(screen.getByText("Save correction feedback to Margin's local learning system as you write")).toBeInTheDocument();
     expect(screen.getByRole("switch")).toBeInTheDocument();
   });
 
@@ -24,6 +25,6 @@ describe("WritingSection", () => {
     render(<WritingSection {...defaultProps} setSetting={setSetting} />);
 
     await user.click(screen.getByRole("switch"));
-    expect(setSetting).toHaveBeenCalledWith("persistCorrections", true);
+    expect(setSetting).toHaveBeenCalledWith("persistCorrections", false);
   });
 });

--- a/src/hooks/__tests__/useAnnotations.test.ts
+++ b/src/hooks/__tests__/useAnnotations.test.ts
@@ -159,4 +159,22 @@ describe("useAnnotations", () => {
       expect(result.current.marginNotes[0]?.highlight_id).toBe("h2");
     });
   });
+
+  describe("continuous feedback preference", () => {
+    it("passes the enabled preference when saving correction feedback", async () => {
+      mockInvoke.mockResolvedValueOnce(fakeNote("n1", "h1"));
+      const { result } = renderHook(() => useAnnotations(undefined, true));
+
+      await act(async () => {
+        await result.current.createMarginNoteWithIntent("h1", "Use evidence.", "correction");
+      });
+
+      expect(mockInvoke).toHaveBeenCalledWith("create_margin_note", {
+        highlightId: "h1",
+        content: "Use evidence.",
+        intent: "correction",
+        captureFeedback: true,
+      });
+    });
+  });
 });

--- a/src/hooks/__tests__/useSettings.test.ts
+++ b/src/hooks/__tests__/useSettings.test.ts
@@ -26,7 +26,7 @@ function mockMatchMedia(matches: boolean) {
 
 const DEFAULTS = {
   theme: "system",
-  persistCorrections: false,
+  persistCorrections: true,
   fontFamily: "serif",
   fontSize: "default",
   lineSpacing: "default",

--- a/src/hooks/useAnnotations.ts
+++ b/src/hooks/useAnnotations.ts
@@ -37,7 +37,10 @@ export interface UseAnnotationsReturn {
   restoreFromCache: (documentId: string, highlights: Highlight[], marginNotes: MarginNote[]) => void;
 }
 
-export function useAnnotations(onMutate?: () => void): UseAnnotationsReturn {
+export function useAnnotations(
+  onMutate?: () => void,
+  captureFeedback = false,
+): UseAnnotationsReturn {
   const [highlights, setHighlights] = useState<Highlight[]>([]);
   const [marginNotes, setMarginNotes] = useState<MarginNote[]>([]);
   const [isLoaded, setIsLoaded] = useState(false);
@@ -115,12 +118,13 @@ export function useAnnotations(onMutate?: () => void): UseAnnotationsReturn {
         highlightId,
         content,
         intent,
+        captureFeedback,
       });
       setMarginNotes((prev) => [...prev, note]);
       onMutate?.();
       return note;
     },
-    [onMutate],
+    [onMutate, captureFeedback],
   );
 
   const createMarginNote = useCallback(
@@ -131,7 +135,7 @@ export function useAnnotations(onMutate?: () => void): UseAnnotationsReturn {
 
   const updateMarginNote = useCallback(
     async (id: string, content: string) => {
-      await invoke("update_margin_note", { id, content });
+      await invoke("update_margin_note", { id, content, captureFeedback });
       setMarginNotes((prev) =>
         prev.map((n) =>
           n.id === id ? { ...n, content, updated_at: Date.now() } : n,
@@ -139,14 +143,14 @@ export function useAnnotations(onMutate?: () => void): UseAnnotationsReturn {
       );
       onMutate?.();
     },
-    [onMutate],
+    [onMutate, captureFeedback],
   );
 
   const deleteMarginNote = useCallback(async (id: string) => {
-    await invoke("delete_margin_note", { id });
+    await invoke("delete_margin_note", { id, captureFeedback });
     setMarginNotes((prev) => prev.filter((n) => n.id !== id));
     onMutate?.();
-  }, [onMutate]);
+  }, [onMutate, captureFeedback]);
 
   const clearAnnotations = useCallback(async (documentId: string) => {
     await invoke("delete_all_highlights_for_document", { documentId });

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -12,7 +12,7 @@ export interface Settings {
 
 export const DEFAULT_SETTINGS: Settings = {
   theme: "system",
-  persistCorrections: false,
+  persistCorrections: true,
   fontFamily: "serif",
   fontSize: "default",
   lineSpacing: "default",

--- a/src/lib/browser-stubs/core.ts
+++ b/src/lib/browser-stubs/core.ts
@@ -167,6 +167,7 @@ const handlers: Record<string, (args: Record<string, unknown>) => unknown> = {
   persist_corrections: () => "mock-export-id",
   get_all_corrections: () => [],
   get_corrections_count: () => 0,
+  sync_feedback_signal: () => true,
   get_corrections_by_document: () => [],
   get_corrections_flat: () => [],
   update_correction_writing_type: () => undefined,

--- a/src/lib/tauri-commands.ts
+++ b/src/lib/tauri-commands.ts
@@ -85,6 +85,14 @@ export async function getCorrectionsByDocument(limit?: number): Promise<Document
   );
 }
 
+export async function syncFeedbackSignal(
+  highlightId: string,
+  polarity: "positive" | "corrective" | null,
+  rationale: string | null,
+): Promise<boolean> {
+  return invoke<boolean>("sync_feedback_signal", { highlightId, polarity, rationale });
+}
+
 export async function updateCorrectionWritingType(highlightId: string, writingType: WritingType): Promise<void> {
   return invoke<void>("update_correction_writing_type", { highlightId, writingType });
 }

--- a/src/styles/editor.css
+++ b/src/styles/editor.css
@@ -125,6 +125,11 @@
   transform: scale(0.95);
 }
 
+.toolbar-btn--active {
+  color: var(--color-text-primary);
+  background-color: var(--active-bg);
+}
+
 .toolbar-btn:focus-visible {
   outline: 2px solid var(--color-text-secondary);
   outline-offset: -1px;


### PR DESCRIPTION
## Summary

- add inline formatting controls for selected Markdown text
- capture accepted, rejected, and corrected writing feedback in SQLite when continuous learning is enabled
- add an opt-out setting and document the two product pillars

## Verification

- `scripts/verify`
- 294 frontend tests
- 184 MCP tests
- 231 Rust tests
- production build and Cargo check